### PR TITLE
DSAR completeness: chunked events + accesses-all + per-access history (0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## 0.5.0 — 2026-06-13 — Chunked events + access-history completeness (DSAR)
+
+Three DSAR-completeness items in a single release:
+
+- **Chunked events fetch** — closes the last completeness gap noted in 0.3.0's "Known gaps" section: the single-shot `events?fromTime=…&toTime=…` round-trip is replaced with monthly time-range chunks so multi-GB subjects (long-running research participants, fitness-tracker subjects with years of high-frequency series, etc.) don't time out at the API gateway or OOM the caller's environment.
+- **`accesses-all.json` (deletions + expired)** — the disclosure history now covers revoked and expired access tokens, which is what GDPR Art.15(1)(c) (recipients), Art.15(1)(a) (purposes of processing — consent-state-at-time-of-access provenance) and CCPA §1798.110 actually require. The current snapshot (`accesses.json`) is still written as before, so anything that currently keys on `accessId` keeps working.
+- **Per-access version history (opt-in)** — `accesses-history/<accessId>.json` per access, fetched via `GET /accesses/<id>?includeHistory=true`. Off by default (O(N) calls); the CLI prompts at startup.
+
+### Added
+
+- **Chunked events fetch.** New module `src/methods/events-chunked.js` probes the subject's earliest and latest event time with two `limit=1` calls (sortAscending=true for the floor, default desc for the ceiling), then iterates monthly UTC-aligned windows. Each window writes its own file `events-YYYY-MM.json` carrying the standard API response shape `{ events: [...], meta: {...} }`. Default chunk size is 1 month; the CLI prompts for an override.
+- **`accesses-all.json`** — second fetch of `GET /accesses?includeDeletions=true&includeExpired=true` runs alongside the standard current-snapshot `accesses.json`. The response shape mirrors `accesses.json` and adds an `accessDeletions` array with all soft-deleted (revoked) access rows. Useful when an Art.15 / Art.20 / §1798.110 disclosure needs the full sharing-history view, not just the live-tokens snapshot. (CMC counterparty metadata — `clientData.cmc.counterparty` + `clientData.cmc.apiEndpoint` — was already in `accesses.json` today; the API exposes the full `clientData` field verbatim, so no extra fetch is needed for cross-border narrative.)
+- **`accesses-history/<accessId>.json`** — per-access version-history files, opt-in via a new CLI prompt ("Also fetch per-access version history?"). Each file carries `{ access, history: [...], current }` per the `accesses.getOne?includeHistory=true` response shape. Off by default because it's O(N) in the access count; a typical subject has ≤20 accesses, but a long-running deployment may have hundreds. Discharged what was listed as the "Per-access version history" gap.
+- **`backup-directory` chunk helpers** — `BackupDirectory#hasEventsData()` returns true when either the legacy `events.json` or any `events-YYYY-MM.json` is present; `BackupDirectory#listEventFiles()` returns all event-data files sorted (legacy first, then chunks). Used by both the backup skip-check and the restore-side concatenation.
+- **`BackupDirectory#accessesAllFile`** alongside `accessesFile`; **`BackupDirectory#accessesHistoryDir`** for the per-access version-history directory.
+- **`apiResources.toJSONFile`** accepts an optional `filename` override (used by the access-history walker to produce `<accessId>.json` files without leaking the `accesses_…` prefix the resource-derived naming would otherwise create).
+- **`[PACE]` + `[PAVH]` test suites** (`test/unit/events-chunked.test.js`) — 12 `[PACE]` tests covering monthly window math (year-boundary crossing, `chunkMonths>1` quarterly chunks, `from==to` instant subject, first/last-window clipping), `formatLabel` zero-padding, and chunk-file discovery, plus 2 `[PAVH]` tests covering the `accesses-all` file path and the `accesses-history` directory path. Run without credentials.
+
+### Changed
+
+- **Restore-side `restoreEvents`** now scans for both legacy `events.json` and any `events-YYYY-MM.json` chunks, concatenates the `events` arrays in sorted order, and buckets into standard / with-attachments / series as before. Backups produced by 0.4.0 and earlier still restore cleanly.
+- **CLI `scripts/start-backup.js`** prompts for the events chunk size (default 1 month). The "events already exist" overwrite check now keys on `hasEventsData()` instead of the bare `events.json` path, and deletes all event-data files (legacy + chunks) on full restart.
+- **CLI `scripts/start-restore.js`** accepts either a directory carrying `events.json` (older backups) or any `events-YYYY-MM.json` (0.5.0+) as a valid backup source.
+
+### Compatibility
+
+- Backups produced by 0.4.0 and earlier (`events.json` single-file) restore against 0.5.0 with no migration step.
+- Manifests produced by 0.5.0 hash each chunk file independently; the integrity verification flow is unchanged (`manifest.verify(rootDir, cb)`).
+- `audit/logs?fromTime=…&toTime=…` remains a single-shot fetch in this release — chunking the audit log is a separate concern (the audit row volume is typically orders of magnitude smaller than user events).
+
+### Known gaps still open after this release
+
+- **Jurisdiction inference per counterparty host** — `clientData.cmc.counterparty.host` carries the federation hostname but jurisdiction-per-host is the implementer's responsibility (no host-to-country registry in the API).
+
+### Operator security note
+
+The backup bundle includes `profile_private.json`, which carries `profile.mfa = { content, recoveryCodes }` verbatim. The 10 recovery codes can bypass the SMS challenge to deactivate MFA, and `content` may carry the subject's phone number. **Treat the backup as a secret on par with a password-reset link** — transport over a secure channel, document destruction policy, and consider rotating recovery codes (re-run MFA activate-confirm on the source account) after the disclosure is complete. The 0.4.0 → 0.5.0 transition does not change this behavior; the note is added here because the symmetry audit re-verified that this is by-design (the subject IS entitled to their full MFA state).
+
 ## 0.4.0 — 2026-05-22 — Dependency upgrade + multi-attachment restore (Plan 72 follow-up)
 
 Squashed into the same Plan 72 Phase C session: comprehensive dependency upgrade to clear the GitHub Dependabot queue and lift the `pryv@2.3.3` single-attachment limitation that 0.3.0's restore-side notes documented as a known gap.

--- a/README.md
+++ b/README.md
@@ -31,9 +31,9 @@ Your data will be downloaded in `./backup/{apiEndpoint}/`
 
 This downloads the following in JSON format:
 * Public profile
-* Accesses
+* Accesses — current-snapshot `accesses.json` **plus `accesses-all.json` (revoked + expired) since 0.5.0**, and optional **`accesses-history/<accessId>.json`** per access (via `?includeHistory=true`, opt-in CLI prompt) for the full disclosure-history view (consent-state-at-time-of-access provenance)
 * Streams
-* Events
+* Events — **chunked by UTC month into `events-YYYY-MM.json` files since 0.5.0** so multi-GB subjects don't time out the single round-trip; older backups stay in a single `events.json` and restore cleanly
 * Account Info
 * **Audit log** (`audit_logs.json`) — every audited operation on the subject (added in 0.3.0)
 * **Webhooks** per access (`webhooks.json`, keyed by `accessId`) — added in 0.3.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pryv/account-backup",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pryv/account-backup",
-      "version": "0.3.0",
+      "version": "0.4.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^3.2.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pryv/account-backup",
   "description": "Backup your Pryv account",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": false,
   "keywords": [
     "Pryv",

--- a/scripts/start-backup.js
+++ b/scripts/start-backup.js
@@ -56,17 +56,39 @@ async.series([
         done(err);
       });
   },
+  function askIncludeAccessHistory (done) {
+    readP({
+      prompt: 'Also fetch per-access version history? (O(N) calls, default N) Y/N : ',
+      silent: false
+    }, function (err, res) {
+      context.includeAccessHistory = (res.toLowerCase() === 'y');
+      done(err);
+    });
+  },
+  function askEventsChunkMonths (done) {
+    readP({ prompt: 'Events chunk size in months (default 1) : ', silent: false },
+      function (err, res) {
+        const n = parseInt((res || '').trim(), 10);
+        context.eventsChunkMonths = (Number.isFinite(n) && n > 0) ? n : 1;
+        done(err);
+      });
+  },
   function askOverwriteEvents (done) {
     const apiEndpoint = pryv.Service.buildAPIEndpoint(context.info, context.username);
     context.backupDirectory = new BackupDirectory(apiEndpoint);
-    if (fs.existsSync(context.backupDirectory.eventsFile)) {
+    if (context.backupDirectory.hasEventsData()) {
       readP({
-        prompt: context.backupDirectory.eventsFile + ' exists, restart attachments sync only?\n' +
-          '[N] will delete current events.json file and backup everything Y/N ? (default Y)',
+        prompt: 'Event files already exist in ' + context.backupDirectory.baseDir + '. ' +
+          'Restart attachments sync only?\n' +
+          '[N] will delete existing event files and backup everything Y/N ? (default Y)',
         silent: false
       }, function (err, resetQ) {
         if (resetQ.toLowerCase() === 'n') {
-          fs.unlinkSync(context.backupDirectory.eventsFile);
+          // Remove legacy single-file + all chunked event files so the
+          // backup re-fetches from scratch.
+          for (const file of context.backupDirectory.listEventFiles()) {
+            fs.unlinkSync(file);
+          }
           console.log('Full backup restart');
         }
         done(err);

--- a/scripts/start-restore.js
+++ b/scripts/start-restore.js
@@ -12,10 +12,19 @@ function readP (opts, callback) {
   read(opts).then((value) => callback(null, value)).catch(callback);
 }
 
-// check BackupDirectory
+// Accept either legacy single-file events.json (older backups) or any chunked
+// events-YYYY-MM.json (0.5.0+) as evidence that the directory is a valid
+// backup source.
+function backupHasEvents (dir) {
+  if (fs.existsSync(path.join(dir, 'events.json'))) return true;
+  if (!fs.existsSync(dir)) return false;
+  return fs.readdirSync(dir).some((n) => n.startsWith('events-') && n.endsWith('.json'));
+}
+
 if (process.argv[2]) {
-  if (!fs.existsSync(path.join(process.argv[2], 'events.json'))) { // skip
-    console.log('Directory [' + process.argv[2] + '] is not a valid directory');
+  if (!backupHasEvents(process.argv[2])) { // skip
+    console.log('Directory [' + process.argv[2] + '] is not a valid backup directory ' +
+      '(no events.json or events-YYYY-MM.json found)');
   } else {
     context.backupSource = process.argv[2];
   }

--- a/src/main.js
+++ b/src/main.js
@@ -4,6 +4,8 @@ const apiResources = require('./methods/api-resources');
 const attachments = require('./methods/attachments');
 const hfData = require('./methods/hf-data');
 const webhooksExport = require('./methods/webhooks-export');
+const eventsChunked = require('./methods/events-chunked');
+const accessesHistory = require('./methods/accesses-history');
 const manifest = require('./methods/manifest');
 const pryv = require('pryv');
 const pkg = require('../package.json');
@@ -60,32 +62,54 @@ function startOnConnection (connection, params, callback, log) {
     function fetchData (done) {
       log('Starting Backup');
 
-      // TODO we skip all data if events are skipped - need more granularity
-      if (fs.existsSync(backupDirectory.eventsFile)) { // skip
+      // Skip on re-run if any events chunk file (or the legacy `events.json`)
+      // already exists. Granularity is "events present? skip the metadata
+      // resources too" — same behavior as pre-chunked versions.
+      if (backupDirectory.hasEventsData()) { // skip
         return done();
       }
 
-      let eventsRequest = 'events?fromTime=-2350373077&toTime=2350373077';
       let streamsRequest = 'streams';
-      let auditLogsRequest = 'audit/logs?fromTime=-2350373077&toTime=2350373077';
+      const auditLogsRequest = 'audit/logs?fromTime=-2350373077&toTime=2350373077';
       if (params.includeTrashed) {
-        eventsRequest += '&state=all';
         streamsRequest += '?state=all';
       }
 
       // 'followed-slices' is v1-only (returns 404 in v2) — not fetched.
-      // 'audit/logs' is fetched alongside the rest as a JSON file.
-      async.mapSeries(['account', streamsRequest, 'accesses',
+      // Events are fetched separately as monthly chunks (see fetchEventsChunked
+      // below); audit/logs is still a single resource.
+      //
+      // `accesses` is fetched twice: once as the current-snapshot
+      // `accesses.json` (back-compat, unchanged shape), once with
+      // `includeDeletions=true&includeExpired=true` as `accesses-all.json`
+      // so the dump carries the full disclosure-history view (revoked +
+      // expired tokens) needed for consent-state-at-time-of-access
+      // provenance.
+      const accessesAllRequest = 'accesses?includeDeletions=true&includeExpired=true';
+      async.mapSeries(['account', streamsRequest, 'accesses', accessesAllRequest,
         'profile/private', 'profile/public',
-        eventsRequest, auditLogsRequest]
+        auditLogsRequest]
         ,
         function (resource, callback) {
+          // Force `accesses-all.json` for the deletions+expired variant so it
+          // doesn't collide with the bare `accesses.json` filename derived
+          // from the resource string.
+          const extra = resource === accessesAllRequest ? '-all' : '';
           apiResources.toJSONFile({
             folder: backupDirectory.baseDir,
             resource: resource,
+            extraFileName: extra,
             connection: connection
           }, callback, log)
         }, done);
+    },
+    function fetchEventsChunked (stepDone) {
+      eventsChunked.download(connection, backupDirectory, {
+        includeTrashed: params.includeTrashed,
+        fromTime: params.fromTime,
+        toTime: params.toTime,
+        chunkMonths: params.eventsChunkMonths
+      }, stepDone, log);
     },
     function fetchAppProfiles (stepDone) {
       const accessesData = JSON.parse(fs.readFileSync(backupDirectory.accessesFile, 'utf8'));
@@ -100,6 +124,14 @@ function startOnConnection (connection, params, callback, log) {
           connection: { endpoint: connection.endpoint, token: access.token }
         }, callback, log);
       }, stepDone);
+    },
+    function fetchAccessHistory (stepDone) {
+      // O(N) in the access count — opt-in via params.includeAccessHistory.
+      if (!params.includeAccessHistory) {
+        log('Skipping per-access version history (opt-in)');
+        return stepDone();
+      }
+      accessesHistory.download(connection, backupDirectory, stepDone, log);
     },
     function fetchAttachments (stepDone) {
       if (params.includeAttachments) {

--- a/src/methods/accesses-history.js
+++ b/src/methods/accesses-history.js
@@ -1,0 +1,77 @@
+const fs = require('fs');
+const path = require('path');
+const apiResources = require('./api-resources');
+
+/**
+ * Fetch per-access version history for every access listed in `accesses.json`.
+ *
+ * Each access is queried with `GET /accesses/<id>?includeHistory=true`, which
+ * returns `{ access, history, current }`. Written one file per access at
+ * `accesses-history/<accessId>.json`. Useful when an Art.15(1)(a) DSAR needs
+ * the consent-state-at-time-of-access provenance trail beyond what
+ * `accesses-all.json` (current + deletions + expired) carries.
+ *
+ * This is O(N) in the access count; opt-in only.
+ *
+ * @param connection { endpoint, token }
+ * @param backupDirectory BackupDirectory instance
+ * @param callback (err)
+ * @param log (msg)
+ */
+exports.download = function download (connection, backupDirectory, callback, log) {
+  if (!log) log = console.log;
+
+  if (!fs.existsSync(backupDirectory.accessesFile)) {
+    log('No accesses.json present — skipping per-access history.');
+    return callback();
+  }
+
+  let accessesData;
+  try {
+    accessesData = JSON.parse(fs.readFileSync(backupDirectory.accessesFile, 'utf8'));
+  } catch (err) {
+    return callback(err);
+  }
+  const accesses = Array.isArray(accessesData.accesses) ? accessesData.accesses : [];
+  if (accesses.length === 0) {
+    log('No accesses to walk for version history.');
+    return callback();
+  }
+
+  // Output dir
+  try {
+    fs.mkdirSync(backupDirectory.accessesHistoryDir, { recursive: true });
+  } catch (err) {
+    return callback(err);
+  }
+
+  log('Fetching per-access version history for ' + accesses.length + ' access(es).');
+
+  let i = 0;
+  function next () {
+    if (i >= accesses.length) return callback();
+    const access = accesses[i++];
+    const accessId = access && access.id;
+    if (!accessId) return next();
+    // Access ids in the wire format are `<base>:<serial>` composite refs; the
+    // accesses.getOne endpoint accepts either the composite or the base. Use
+    // the composite as-is so the history call lands on the same head row.
+    apiResources.toJSONFile({
+      folder: backupDirectory.accessesHistoryDir,
+      resource: 'accesses/' + encodeURIComponent(accessId) + '?includeHistory=true',
+      // api-resources derives the filename by replacing '/' with '_' and
+      // stripping the '?…' suffix, so this yields `accesses_<accessId>.json`
+      // — collapse to just `<accessId>.json` via extraFileName override below.
+      extraFileName: '',
+      connection: connection,
+      filename: encodeURIComponent(accessId) + '.json'
+    }, function (err) {
+      if (err) {
+        // Log + continue — one failed access shouldn't abort the whole walk.
+        log('Failed to fetch history for access ' + accessId + ': ' + err);
+      }
+      next();
+    }, log);
+  }
+  next();
+};

--- a/src/methods/api-resources.js
+++ b/src/methods/api-resources.js
@@ -25,7 +25,11 @@ exports.toJSONFile = function streamApiToFile(params, callback, log) {
 
   function openStreamsIfNeeded() {
       if (outputFilename) return;
-     outputFilename = params.resource.replace('/', '_').split('?')[0] + params.extraFileName + '.json';
+     // `params.filename`, when present, overrides the resource-derived name
+     // (used by accesses-history to produce one file per composite access
+     // id without leaking `accesses_…` prefixes).
+     outputFilename = params.filename ||
+       (params.resource.replace('/', '_').split('?')[0] + params.extraFileName + '.json');
      fullPath = params.folder  + outputFilename;
      writeStream = fs.createWriteStream(fullPath, { encoding: 'utf8' });
      log('Streaming data to: ' + fullPath);

--- a/src/methods/backup-directory.js
+++ b/src/methods/backup-directory.js
@@ -22,9 +22,12 @@ const BackupDirectory = module.exports = function (apiEndpoint, dir) {
   this.attachmentsDir = path.resolve(this.baseDir, 'attachments') + '/';
   this.appProfilesDir = path.resolve(this.baseDir, 'app_profiles') + '/';
   this.hfDataDir = path.resolve(this.baseDir, 'hf-data') + '/';
-  this.eventsFile = path.resolve(this.baseDir, 'events.json');
+  this.accessesHistoryDir = path.resolve(this.baseDir, 'accesses-history') + '/'; // 0.5.0+: per-access version-history files (opt-in)
+  this.eventsFile = path.resolve(this.baseDir, 'events.json'); // legacy single-shot file (pre-0.5.0)
+  this.eventsChunkPrefix = 'events-'; // 0.5.0+ chunked files: events-YYYY-MM.json
   this.streamsFile = path.resolve(this.baseDir, 'streams.json');
   this.accessesFile = path.resolve(this.baseDir, 'accesses.json');
+  this.accessesAllFile = path.resolve(this.baseDir, 'accesses-all.json'); // 0.5.0+: deletions + expired
   this.auditLogsFile = path.resolve(this.baseDir, 'audit_logs.json');
   this.webhooksFile = path.resolve(this.baseDir, 'webhooks.json');
   this.manifestFile = path.resolve(this.baseDir, 'manifest.json');
@@ -102,6 +105,41 @@ BackupDirectory.prototype.createDirs = function (callback, log) {
       }.bind(this));
     }.bind(this)
   ], callback);
+};
+
+/**
+ * Whether the backup directory already carries event data (legacy single-file
+ * `events.json` or any chunked `events-YYYY-MM.json`). Used to short-circuit
+ * re-runs that should resume rather than re-fetch.
+ * @returns {boolean}
+ */
+BackupDirectory.prototype.hasEventsData = function () {
+  if (fs.existsSync(this.eventsFile)) return true;
+  if (!fs.existsSync(this.baseDir)) return false;
+  const entries = fs.readdirSync(this.baseDir);
+  for (const name of entries) {
+    if (name.startsWith(this.eventsChunkPrefix) && name.endsWith('.json')) return true;
+  }
+  return false;
+};
+
+/**
+ * List event-data files in the backup directory, in sorted order. Includes
+ * both the legacy single-file `events.json` (older backups) and chunked
+ * `events-YYYY-MM.json` files (0.5.0+). Returns absolute paths.
+ * @returns {string[]}
+ */
+BackupDirectory.prototype.listEventFiles = function () {
+  const files = [];
+  if (fs.existsSync(this.eventsFile)) files.push(this.eventsFile);
+  if (fs.existsSync(this.baseDir)) {
+    const entries = fs.readdirSync(this.baseDir).filter((n) =>
+      n.startsWith(this.eventsChunkPrefix) && n.endsWith('.json')
+    );
+    entries.sort();
+    for (const name of entries) files.push(path.resolve(this.baseDir, name));
+  }
+  return files;
 };
 
 /**

--- a/src/methods/events-chunked.js
+++ b/src/methods/events-chunked.js
@@ -1,0 +1,169 @@
+const https = require('https');
+const apiResources = require('./api-resources');
+
+const FAR_PAST = -2350373077;
+const FAR_FUTURE = 2350373077;
+const SECONDS_PER_DAY = 86400;
+
+/**
+ * Fetch events split into monthly time-range chunks instead of a single
+ * unbounded request. For a subject with multi-GB event history, a single
+ * `events?fromTime=…&toTime=…` round-trip times out at the API gateway or
+ * OOMs the caller; one file per UTC month keeps each round-trip bounded.
+ *
+ * Output files: `events-YYYY-MM.json` (one per non-empty month in the
+ * discovered range). Each file carries the standard API response shape
+ * `{ events: [...], meta: {...} }` — readable with the same JSON tooling as
+ * the rest of the dump and individually hashable by the integrity manifest.
+ *
+ * @param connection { endpoint, token }
+ * @param backupDirectory BackupDirectory instance (provides baseDir)
+ * @param options
+ *        options.includeTrashed {boolean}  appends `&state=all`
+ *        options.fromTime {number}         optional override (seconds since epoch)
+ *        options.toTime {number}           optional override (seconds since epoch)
+ *        options.chunkMonths {number}      default 1 (months per chunk)
+ * @param callback (err)
+ * @param log (msg)
+ */
+exports.download = function download (connection, backupDirectory, options, callback, log) {
+  if (!log) log = console.log;
+  options = options || {};
+  const chunkMonths = options.chunkMonths || 1;
+  const stateAll = options.includeTrashed ? '&state=all' : '';
+
+  probeRange(connection, stateAll, options, log, function (probeErr, range) {
+    if (probeErr) return callback(probeErr);
+    if (range == null) {
+      log('No events found in subject account — skipping chunked events fetch.');
+      return callback();
+    }
+
+    const windows = computeMonthlyWindows(range.from, range.to, chunkMonths);
+    log('Events range: ' + new Date(range.from * 1000).toISOString() +
+      ' → ' + new Date(range.to * 1000).toISOString() +
+      ' (' + windows.length + ' window(s) of ' + chunkMonths + ' month(s))');
+
+    let i = 0;
+    function next () {
+      if (i >= windows.length) return callback();
+      const w = windows[i++];
+      const resource = 'events?fromTime=' + w.from + '&toTime=' + w.to + stateAll;
+      // api-resources.toJSONFile derives the filename by stripping `?…` from
+      // the resource string, so passing the full query yields `events-YYYY-MM.json`.
+      apiResources.toJSONFile({
+        folder: backupDirectory.baseDir,
+        resource: resource,
+        extraFileName: '-' + w.label,
+        connection: connection
+      }, function (err) {
+        if (err) return callback(err);
+        next();
+      }, log);
+    }
+    next();
+  });
+};
+
+/**
+ * Discover the earliest + latest event timestamp on the subject account.
+ * Returns `{ from, to }` (seconds-since-epoch) or `null` when the subject has
+ * zero events.
+ *
+ * Uses 1-event probes — sortAscending=true for the floor, default desc for
+ * the ceiling. Honors `options.fromTime` / `options.toTime` overrides without
+ * probing when both are supplied.
+ */
+function probeRange (connection, stateAll, options, log, callback) {
+  if (options.fromTime != null && options.toTime != null) {
+    return callback(null, { from: options.fromTime, to: options.toTime });
+  }
+
+  const baseRange = 'fromTime=' + FAR_PAST + '&toTime=' + FAR_FUTURE + stateAll;
+  apiGet(connection, '/events?limit=1&sortAscending=true&' + baseRange, function (err, earliest) {
+    if (err) return callback(err);
+    if (!earliest || !earliest.events || earliest.events.length === 0) {
+      return callback(null, null);
+    }
+    apiGet(connection, '/events?limit=1&' + baseRange, function (err2, latest) {
+      if (err2) return callback(err2);
+      const from = (options.fromTime != null) ? options.fromTime : earliest.events[0].time;
+      const to = (options.toTime != null) ? options.toTime : latest.events[0].time;
+      callback(null, { from: from, to: to });
+    });
+  });
+}
+
+/**
+ * Slice [from, to] into UTC-month-aligned windows.
+ * Windows are half-open `[from, to)` on the seconds axis except the last,
+ * which is closed at `to`. Empty windows are still emitted — the API call
+ * happily returns `events: []` and the manifest hashes the empty file. (The
+ * caller can choose to skip-on-empty in a later pass; for now we keep it
+ * simple and predictable.)
+ */
+function computeMonthlyWindows (fromSec, toSec, chunkMonths) {
+  const fromMs = fromSec * 1000;
+  const toMs = toSec * 1000;
+  const start = new Date(fromMs);
+  const startUtc = Date.UTC(start.getUTCFullYear(), start.getUTCMonth(), 1);
+
+  const windows = [];
+  let cursorMs = startUtc;
+  while (cursorMs <= toMs) {
+    const cursor = new Date(cursorMs);
+    const nextMs = Date.UTC(cursor.getUTCFullYear(), cursor.getUTCMonth() + chunkMonths, 1);
+    const windowFromSec = Math.max(Math.floor(cursorMs / 1000), fromSec);
+    const windowToSec = Math.min(Math.floor(nextMs / 1000) - 1, toSec);
+    if (windowFromSec > windowToSec) {
+      cursorMs = nextMs;
+      continue;
+    }
+    windows.push({
+      from: windowFromSec,
+      to: windowToSec,
+      label: formatLabel(cursor)
+    });
+    cursorMs = nextMs;
+  }
+  // Guarantee at least one window when from == to (single-instant subject).
+  if (windows.length === 0) {
+    windows.push({ from: fromSec, to: toSec, label: formatLabel(new Date(fromMs)) });
+  }
+  return windows;
+}
+
+function formatLabel (date) {
+  const y = date.getUTCFullYear();
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return y + '-' + m;
+}
+
+function apiGet (connection, pathAndQuery, callback) {
+  const url = new URL(connection.endpoint);
+  const fullPath = url.pathname.replace(/\/$/, '') + pathAndQuery;
+  const opts = {
+    host: url.hostname,
+    port: url.port || 443,
+    path: fullPath,
+    headers: { Authorization: connection.token }
+  };
+  https.get(opts, function (res) {
+    if (res.statusCode !== 200) {
+      return callback(new Error('Probe failed: ' + res.statusCode + ' ' + res.statusMessage));
+    }
+    let body = '';
+    res.setEncoding('utf8');
+    res.on('data', function (chunk) { body += chunk; });
+    res.on('end', function () {
+      try { callback(null, JSON.parse(body)); } catch (e) { callback(e); }
+    });
+  }).on('error', callback);
+}
+
+// Exported for unit tests.
+exports._computeMonthlyWindows = computeMonthlyWindows;
+exports._formatLabel = formatLabel;
+exports.FAR_PAST = FAR_PAST;
+exports.FAR_FUTURE = FAR_FUTURE;
+exports.SECONDS_PER_DAY = SECONDS_PER_DAY;

--- a/src/restore.js
+++ b/src/restore.js
@@ -1,6 +1,24 @@
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * Return event-data files in a backup directory, sorted. Includes the legacy
+ * single-file `events.json` (older backups) and any chunked
+ * `events-YYYY-MM.json` (0.5.0+).
+ */
+function listEventFiles (sourcePath) {
+  const files = [];
+  const legacy = path.join(sourcePath, 'events.json');
+  if (fs.existsSync(legacy)) files.push(legacy);
+  if (fs.existsSync(sourcePath)) {
+    const chunks = fs.readdirSync(sourcePath)
+      .filter((n) => n.startsWith('events-') && n.endsWith('.json'))
+      .sort();
+    for (const name of chunks) files.push(path.join(sourcePath, name));
+  }
+  return files;
+}
+
 async function restoreStreams (connection, sourcePath) {
   const ressourceFile = path.join(sourcePath, 'streams.json');
   const content = JSON.parse(fs.readFileSync(ressourceFile, 'utf-8'));
@@ -22,12 +40,25 @@ async function restoreStreams (connection, sourcePath) {
 }
 
 async function restoreEvents (connection, sourcePath) {
-  const eventFile = path.join(sourcePath, 'events.json');
-  const content = JSON.parse(fs.readFileSync(eventFile, 'utf-8'));
+  // 0.5.0+ writes one `events-YYYY-MM.json` per chunk; older backups have a
+  // single `events.json`. Read whichever exists (or both, sorted) and
+  // concatenate the `events` arrays before bucketing.
+  const eventFiles = listEventFiles(sourcePath);
+  if (eventFiles.length === 0) {
+    throw new Error('No events.json or events-YYYY-MM.json found in ' + sourcePath);
+  }
+  const allEvents = [];
+  for (const file of eventFiles) {
+    const parsed = JSON.parse(fs.readFileSync(file, 'utf-8'));
+    if (Array.isArray(parsed.events)) {
+      for (const e of parsed.events) allEvents.push(e);
+    }
+  }
+  console.log('Restoring ' + allEvents.length + ' event(s) from ' + eventFiles.length + ' file(s).');
   const standardEvents = [];
   const eventsWithAttachments = [];
   const eventsSeries = [];
-  content.events.forEach((e) => {
+  allEvents.forEach((e) => {
     ['modified', 'modifiedBy', 'streamId', 'created', 'createdBy'].forEach((key) => { delete e[key]; });
     e.streamIds = e.streamIds.filter((streamId) => { return !streamId.startsWith('.'); }); // remove system streams
 

--- a/test/unit/events-chunked.test.js
+++ b/test/unit/events-chunked.test.js
@@ -1,0 +1,160 @@
+/*global describe, it, before, after */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const should = require('should');
+const eventsChunked = require('../../src/methods/events-chunked');
+const Directory = require('../../src/methods/backup-directory');
+
+// Time helpers — work in UTC seconds since epoch.
+function utcSec (y, m, d, h, mi, s) {
+  return Math.floor(Date.UTC(y, m - 1, d || 1, h || 0, mi || 0, s || 0) / 1000);
+}
+
+describe('events-chunked', function () {
+  describe('[PACE] computeMonthlyWindows', function () {
+    it('produces one window per month in the discovered range', function () {
+      const from = utcSec(2024, 1, 5, 12); // 2024-01-05T12:00:00Z
+      const to = utcSec(2024, 3, 20, 8); // 2024-03-20T08:00:00Z
+      const windows = eventsChunked._computeMonthlyWindows(from, to, 1);
+      windows.should.have.length(3);
+      windows[0].label.should.equal('2024-01');
+      windows[1].label.should.equal('2024-02');
+      windows[2].label.should.equal('2024-03');
+    });
+
+    it('aligns windows to UTC month boundaries with no overlap or gap', function () {
+      const from = utcSec(2024, 1, 5);
+      const to = utcSec(2024, 3, 20);
+      const windows = eventsChunked._computeMonthlyWindows(from, to, 1);
+      for (let i = 1; i < windows.length; i++) {
+        // Adjacent windows touch: prev.to + 1 == next.from.
+        (windows[i].from - windows[i - 1].to).should.equal(1);
+      }
+    });
+
+    it('clips the first window to the discovered fromTime (no lookback)', function () {
+      const from = utcSec(2024, 1, 15); // mid-month
+      const to = utcSec(2024, 2, 5);
+      const windows = eventsChunked._computeMonthlyWindows(from, to, 1);
+      windows[0].from.should.equal(from);
+      windows[0].label.should.equal('2024-01');
+    });
+
+    it('clips the last window to the discovered toTime', function () {
+      const from = utcSec(2024, 1, 5);
+      const to = utcSec(2024, 2, 10); // mid-month
+      const windows = eventsChunked._computeMonthlyWindows(from, to, 1);
+      const last = windows[windows.length - 1];
+      last.to.should.equal(to);
+    });
+
+    it('honors chunkMonths > 1', function () {
+      const from = utcSec(2024, 1, 1);
+      const to = utcSec(2024, 6, 30);
+      const windows = eventsChunked._computeMonthlyWindows(from, to, 3); // quarterly
+      windows.should.have.length(2);
+      windows[0].label.should.equal('2024-01');
+      windows[1].label.should.equal('2024-04');
+    });
+
+    it('emits a single window when from == to (instant subject)', function () {
+      const t = utcSec(2024, 6, 15);
+      const windows = eventsChunked._computeMonthlyWindows(t, t, 1);
+      windows.should.have.length(1);
+      windows[0].from.should.equal(t);
+      windows[0].to.should.equal(t);
+    });
+
+    it('crosses year boundary correctly', function () {
+      const from = utcSec(2023, 11, 15);
+      const to = utcSec(2024, 2, 10);
+      const windows = eventsChunked._computeMonthlyWindows(from, to, 1);
+      windows.map((w) => w.label).should.eql([
+        '2023-11', '2023-12', '2024-01', '2024-02'
+      ]);
+    });
+  });
+
+  describe('[PACE] formatLabel', function () {
+    it('zero-pads the month', function () {
+      eventsChunked._formatLabel(new Date(Date.UTC(2024, 0, 1))).should.equal('2024-01');
+      eventsChunked._formatLabel(new Date(Date.UTC(2024, 8, 1))).should.equal('2024-09');
+      eventsChunked._formatLabel(new Date(Date.UTC(2024, 11, 1))).should.equal('2024-12');
+    });
+  });
+
+  describe('[PACE] backup-directory chunk discovery', function () {
+    let tmpDir;
+    let dir;
+
+    before(function () {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'chunk-test-'));
+      // BackupDirectory derives baseDir from the apiEndpoint hostname; pass a
+      // synthetic endpoint that yields a known subdirectory.
+      dir = new Directory('https://token@host.example.com/', tmpDir);
+      fs.mkdirSync(dir.baseDir, { recursive: true });
+    });
+
+    after(function () {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('hasEventsData returns false on an empty directory', function () {
+      dir.hasEventsData().should.equal(false);
+    });
+
+    it('hasEventsData returns true when a chunk file is present', function () {
+      fs.writeFileSync(path.join(dir.baseDir, 'events-2024-01.json'), '{"events":[]}');
+      dir.hasEventsData().should.equal(true);
+    });
+
+    it('listEventFiles returns chunk files in sorted order', function () {
+      fs.writeFileSync(path.join(dir.baseDir, 'events-2024-03.json'), '{"events":[]}');
+      fs.writeFileSync(path.join(dir.baseDir, 'events-2024-02.json'), '{"events":[]}');
+      const files = dir.listEventFiles().map((f) => path.basename(f));
+      files.should.eql([
+        'events-2024-01.json',
+        'events-2024-02.json',
+        'events-2024-03.json'
+      ]);
+    });
+
+    it('listEventFiles includes legacy events.json before chunks', function () {
+      fs.writeFileSync(path.join(dir.baseDir, 'events.json'), '{"events":[]}');
+      const files = dir.listEventFiles().map((f) => path.basename(f));
+      files[0].should.equal('events.json');
+      files.slice(1).should.eql([
+        'events-2024-01.json',
+        'events-2024-02.json',
+        'events-2024-03.json'
+      ]);
+    });
+  });
+
+  describe('[PAVH] accesses-all path in BackupDirectory', function () {
+    let tmpDir;
+    let dir;
+
+    before(function () {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'accesses-all-test-'));
+      dir = new Directory('https://token@host.example.com/', tmpDir);
+      fs.mkdirSync(dir.baseDir, { recursive: true });
+    });
+
+    after(function () {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('exposes accessesAllFile alongside accessesFile', function () {
+      dir.accessesFile.should.endWith('/accesses.json');
+      dir.accessesAllFile.should.endWith('/accesses-all.json');
+      dir.accessesAllFile.should.not.equal(dir.accessesFile);
+    });
+
+    it('exposes accessesHistoryDir for per-access version files', function () {
+      dir.accessesHistoryDir.should.endWith('/accesses-history/');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Three additions to the subject-side backup bundle, closing the remaining read-side gaps for GDPR Art.15 / Art.20, CCPA §1798.110, PIPEDA Principle 4.9, and Swiss nLPD Art.25 at production scale:

- **Chunked events fetch** — `events?fromTime=…&toTime=…` becomes one `events-YYYY-MM.json` per UTC month in the discovered range. Two `limit=1` probes (ascending floor + descending ceiling) bound the window so empty centuries don't produce empty chunks. Default chunk size is 1 month; CLI prompts for an override. Closes the single-shot-fetch / API-gateway-timeout limitation flagged in 0.3.0's "Known gaps" section.
- **`accesses-all.json`** — second fetch of `accesses?includeDeletions=true&includeExpired=true` runs alongside the existing `accesses.json`. Adds `accessDeletions[]` (revoked) and the expired tokens for the full disclosure-history view. The current snapshot is still written as before — any consumer keying on `accessId` keeps working.
- **`accesses-history/<accessId>.json`** — opt-in per-access version history via `?includeHistory=true`. Off by default (O(N) calls); the CLI prompts at startup.

Restore is updated to read both legacy `events.json` and any `events-YYYY-MM.json` chunks, concatenated in sorted order. Pre-0.5 backups restore unchanged.

## Why these three together

All three are read-side DSAR-completeness items surfaced from the same audit of v0.4.0 against subject-facing right-of-access / portability requirements. Bundling them into a single 0.5.0 keeps the disclosure narrative consistent and minimises PR ceremony. Restore-side experimental status is unchanged — audit / webhooks / accesses are still not replayed by design (system-generated or token-bearing).

## Test plan

- [x] `npx mocha test/unit/events-chunked.test.js test/unit/manifest.test.js` — 17/17 green (12 [PACE] + 2 [PAVH] + 3 existing manifest).
- [x] No new credentials-dependent tests added; existing `api-resources.test.js` / `attachments.test.js` / `backup-directory.test.js` still need `test/helpers/testuser.js` to run (pre-existing).
- [ ] Reviewer: run a backup against a real account with `--include-attachments y` + `--include-access-history y` and verify (a) `events-YYYY-MM.json` files cover the account's event range, (b) `accesses-all.json` includes `accessDeletions[]` when soft-deleted accesses exist, (c) `accesses-history/<accessId>.json` is written per access.
- [ ] Reviewer: restore a pre-0.5 backup (single `events.json`) to confirm backward-compatibility on the read path.

## Operator security note

`profile_private.json` carries `profile.mfa = { content, recoveryCodes }` verbatim (10 codes that bypass the SMS challenge). Treat the backup as a secret on par with a password-reset link; consider rotating recovery codes after the disclosure is complete. This is by-design — the subject IS entitled to their full MFA state — but is now explicitly called out in CHANGELOG.

## Files changed (13 files, +605/-25)

- NEW `src/methods/events-chunked.js` — probe + window math + per-window fetch loop.
- NEW `src/methods/accesses-history.js` — opt-in per-access history walker.
- NEW `test/unit/events-chunked.test.js` — [PACE] + [PAVH] unit tests.
- `src/main.js` — split `fetchData` from `fetchEventsChunked`, add `fetchAccessHistory`, second `accesses?includeDeletions=…` fetch.
- `src/methods/backup-directory.js` — `hasEventsData()` / `listEventFiles()` / `accessesAllFile` / `accessesHistoryDir`.
- `src/methods/api-resources.js` — optional `filename` override (used by per-access walker).
- `src/restore.js` — concat legacy + chunked event files in sorted order.
- `scripts/start-backup.js` — prompts for chunk size + include-access-history.
- `scripts/start-restore.js` — accept either legacy or chunked event-file presence.
- `CHANGELOG.md`, `README.md`, `package.json` 0.4.0 → 0.5.0.