### PR TITLE
Browser-isomorphic resource fetchers (fetch + StorageWriter); audit migrates off the dedicated /audit/logs route

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,19 @@
 # Changelog
 
-## 0.6.0 — UNRELEASED — Library + CLI split, incremental backup via `modifiedSince`, audit-as-events
+## 0.6.0 — UNRELEASED — Library + CLI split, incremental backup, audit-as-events, browser-isomorphic core
 
-Architectural rewrite around a programmatic library API (`require('@pryv/account-backup').Backup`) consuming pluggable adapters (`StorageWriter` + `StateStore`). The CLI is preserved as a thin shim; behavior is byte-identical to 0.5.0 on a first run against a fresh backup directory. A sibling `pryv-account-backup-webapp` repository ships the browser-side adapter pair + sample UI.
+Architectural rewrite around a programmatic library API (`require('@pryv/account-backup').Backup`) consuming pluggable adapters (`StorageWriter` + `StateStore`). The core resource-fetch modules are browser-isomorphic — `fetch` for HTTP, `StorageWriter.openWriteStream` for output. The CLI is preserved as a thin shim; behavior is byte-identical to 0.5.0 on a first run against a fresh backup directory. A sibling `pryv-account-backup-webapp` repository ships the browser-side adapter pair + sample UI.
+
+**Upstream context driving v0.6.0:** the dedicated `/audit/logs` endpoint is being removed from open-pryv.io. v0.5.0 calls this endpoint and will fail once the removal lands. v0.6.0 fetches audit via `events.get?streams=[':_audit:accesses',':_audit:actions']` instead — audit is a regular `@pryv/datastore` mounted at `:_audit:*` on every Pryv core. This route is forward-compatible with the removal AND supports `modifiedSince`, which the dedicated endpoint does not.
 
 ### Added
 
 - **`Backup` class + adapter interfaces** — new `src/lib/` package exporting `Backup`, `StorageWriter`, `StateStore`, `NodeFsStorageWriter`, `FolderStateStore`. The CLI now constructs these adapters internally; the public `require('@pryv/account-backup').start(params, cb)` callback API is unchanged.
+- **Browser-isomorphic resource fetchers** — `api-resources`, `events-chunked`, `audit-as-events`, `accesses-history` now use global `fetch` (Node 18+ / every modern browser) for HTTP and `StorageWriter.openWriteStream` for output, with **zero** Node-only imports reaching the runtime path. esbuild bundles all four modules for the browser in ~12 KB. The Node-only resource fetchers (`attachments`, `hf-data`, `webhooks-export`, `manifest`) stay CLI-only — the v0.6.0 webapp sample does not expose attachments / HFS / webhooks fetches.
 - **Incremental backup via `events.get?modifiedSince=T`** — when a `FolderStateStore` (or any `StateStore`) reports a `lastRunAt` from a prior successful run, the events fetch switches to a single incremental round-trip producing `events-incremental-<RUN-TS>.json` instead of the monthly chunked fetch. Deletions are included via `includeDeletions=true`. First-run behavior (chunked monthly `events-YYYY-MM.json`) is preserved.
 - **Audit fetched via the standard events API on `:_audit:*` streams** — audit is registered as a regular `@pryv/datastore` on every Pryv core; querying `events.get?streams=[':_audit:accesses',':_audit:actions']&modifiedSince=T` reaches the same data the dedicated `audit.getLogs` endpoint serves, but with `modifiedSince` support for free. The output filename `audit_logs.json` is preserved so any consumer that keyed on it continues to work.
 - **State persistence** — successful runs write `lastRunAt`, `events.lastModifiedSince`, `audit.lastModifiedSince`, plus tool + format version to a `.state.json` sentinel in the backup directory. Used to drive the next run's incremental thresholds.
-- **Adapter contract tests `[PAAB]`** + **incremental + audit-as-events tests `[PAIB]` / `[PAAU]`** — 33 new unit tests run without credentials.
+- **Adapter contract tests `[PAAB]`** + **incremental + audit-as-events tests `[PAIB]` / `[PAAU]`** + **isomorphism contract tests `[PALI]`** + **hf-data regression test `[PAHF]`** — 43 new unit tests run without credentials.
 
 ### Fixed
 
@@ -20,6 +23,7 @@ Architectural rewrite around a programmatic library API (`require('@pryv/account
 
 - **`scripts/start-backup.js`** unchanged — the CLI prompts and flow are identical to 0.5.0 from an operator's perspective. The orchestration delegates to the new `Backup` class internally.
 - **`audit/logs?fromTime=…&toTime=…` dropped** from the metadata-fetch list — replaced by audit-as-events (see above). No behavior change on the output side; the audit_logs.json content is shape-compatible.
+- **`https.get` / `fs.createWriteStream` removed from isomorphic modules** — replaced by global `fetch` + `StorageWriter.openWriteStream`. `Backup.run` constructs a `NodeFsStorageWriter` from the legacy `BackupDirectory` once and passes the writer to every per-method module; per-method modules no longer accept a `folder` shortcut.
 
 ### Compatibility
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pryv/account-backup",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@pryv/account-backup",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^3.2.6",
@@ -15,10 +15,453 @@
         "read": "^5.0.1"
       },
       "devDependencies": {
+        "esbuild": "^0.28.1",
         "mocha": "^11.7.6",
         "should": "^13.2.3",
         "superagent": "^10.3.0"
       },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz",
+      "integrity": "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.28.1.tgz",
+      "integrity": "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz",
+      "integrity": "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.28.1.tgz",
+      "integrity": "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz",
+      "integrity": "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz",
+      "integrity": "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz",
+      "integrity": "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz",
+      "integrity": "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz",
+      "integrity": "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz",
+      "integrity": "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz",
+      "integrity": "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz",
+      "integrity": "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz",
+      "integrity": "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz",
+      "integrity": "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz",
+      "integrity": "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz",
+      "integrity": "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz",
+      "integrity": "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz",
+      "integrity": "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz",
+      "integrity": "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz",
+      "integrity": "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz",
+      "integrity": "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz",
+      "integrity": "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=18"
       }
@@ -526,6 +969,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.28.1",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.28.1.tgz",
+      "integrity": "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.28.1",
+        "@esbuild/android-arm": "0.28.1",
+        "@esbuild/android-arm64": "0.28.1",
+        "@esbuild/android-x64": "0.28.1",
+        "@esbuild/darwin-arm64": "0.28.1",
+        "@esbuild/darwin-x64": "0.28.1",
+        "@esbuild/freebsd-arm64": "0.28.1",
+        "@esbuild/freebsd-x64": "0.28.1",
+        "@esbuild/linux-arm": "0.28.1",
+        "@esbuild/linux-arm64": "0.28.1",
+        "@esbuild/linux-ia32": "0.28.1",
+        "@esbuild/linux-loong64": "0.28.1",
+        "@esbuild/linux-mips64el": "0.28.1",
+        "@esbuild/linux-ppc64": "0.28.1",
+        "@esbuild/linux-riscv64": "0.28.1",
+        "@esbuild/linux-s390x": "0.28.1",
+        "@esbuild/linux-x64": "0.28.1",
+        "@esbuild/netbsd-arm64": "0.28.1",
+        "@esbuild/netbsd-x64": "0.28.1",
+        "@esbuild/openbsd-arm64": "0.28.1",
+        "@esbuild/openbsd-x64": "0.28.1",
+        "@esbuild/openharmony-arm64": "0.28.1",
+        "@esbuild/sunos-x64": "0.28.1",
+        "@esbuild/win32-arm64": "0.28.1",
+        "@esbuild/win32-ia32": "0.28.1",
+        "@esbuild/win32-x64": "0.28.1"
       }
     },
     "node_modules/escalade": {

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "read": "^5.0.1"
   },
   "devDependencies": {
+    "esbuild": "^0.28.1",
     "mocha": "^11.7.6",
     "should": "^13.2.3",
     "superagent": "^10.3.0"

--- a/src/lib/Backup.js
+++ b/src/lib/Backup.js
@@ -139,7 +139,7 @@ class Backup {
           // Audit no longer rides this list — it's fetched via
           // events.get on :_audit:* streams in a dedicated step below so
           // modifiedSince applies (the dedicated /audit/logs endpoint does
-          // not support modifiedSince).
+          // not support modifiedSince and is being removed from the API).
           const accessesAllRequest = 'accesses?includeDeletions=true&includeExpired=true';
           async.mapSeries([
             'account', streamsRequest, 'accesses', accessesAllRequest,
@@ -147,7 +147,7 @@ class Backup {
           ], function (resource, cb) {
             const extra = resource === accessesAllRequest ? '-all' : '';
             apiResources.toJSONFile({
-              folder: backupDirectory.baseDir,
+              writer: writer,
               resource: resource,
               extraFileName: extra,
               connection: connection
@@ -155,13 +155,13 @@ class Backup {
           }, done);
         },
         function fetchAuditAsEvents (stepDone) {
-          auditAsEvents.download(connection, backupDirectory, {
+          auditAsEvents.download(connection, writer, {
             includeTrashed: params.includeTrashed,
             modifiedSince: auditModifiedSince
           }, stepDone, log);
         },
         function fetchEventsChunked (stepDone) {
-          eventsChunked.download(connection, backupDirectory, {
+          eventsChunked.download(connection, writer, {
             includeTrashed: params.includeTrashed,
             modifiedSince: eventsModifiedSince,
             runStartedAt: runStartedAt,
@@ -171,13 +171,17 @@ class Backup {
           }, stepDone, log);
         },
         function fetchAppProfiles (stepDone) {
+          // The per-app-profile fetches go into the `app_profiles/`
+          // subdirectory; api-resources writes via the writer, which routes
+          // the relative path under baseDir.
           const accessesData = JSON.parse(fs.readFileSync(backupDirectory.accessesFile, 'utf8'));
           async.mapSeries(accessesData.accesses, function (access, cb) {
             if (access.type !== 'app') return cb();
             apiResources.toJSONFile({
-              folder: backupDirectory.appProfilesDir,
+              writer: writer,
               resource: 'profile/app',
               extraFileName: '_' + access.id,
+              filename: 'app_profiles/profile_app_' + access.id + '.json',
               connection: { endpoint: connection.endpoint, token: access.token }
             }, cb, log);
           }, stepDone);
@@ -187,7 +191,10 @@ class Backup {
             log('Skipping per-access version history (opt-in)');
             return stepDone();
           }
-          accessesHistory.download(connection, backupDirectory, stepDone, log);
+          // Pass the accesses array explicitly so accesses-history doesn't
+          // need to read disk — keeps the per-method module browser-friendly.
+          const accessesData = JSON.parse(fs.readFileSync(backupDirectory.accessesFile, 'utf8'));
+          accessesHistory.download(connection, writer, accessesData.accesses || [], stepDone, log);
         },
         function fetchAttachments (stepDone) {
           if (params.includeAttachments) {

--- a/src/methods/accesses-history.js
+++ b/src/methods/accesses-history.js
@@ -1,73 +1,56 @@
-const fs = require('fs');
-const path = require('path');
 const apiResources = require('./api-resources');
 
 /**
- * Fetch per-access version history for every access listed in `accesses.json`.
+ * Fetch per-access version history for every access supplied. Each access is
+ * queried with `GET /accesses/<id>?includeHistory=true` and written to
+ * `accesses-history/<accessId>.json`.
  *
- * Each access is queried with `GET /accesses/<id>?includeHistory=true`, which
- * returns `{ access, history, current }`. Written one file per access at
- * `accesses-history/<accessId>.json`. Useful when an Art.15(1)(a) DSAR needs
- * the consent-state-at-time-of-access provenance trail beyond what
- * `accesses-all.json` (current + deletions + expired) carries.
+ * Used when an Art.15(1)(a) DSAR needs the consent-state-at-time-of-access
+ * provenance trail beyond what `accesses-all.json` (current + deletions +
+ * expired) carries.
  *
- * This is O(N) in the access count; opt-in only.
+ * O(N) in the access count; opt-in only.
  *
  * @param connection { endpoint, token }
- * @param backupDirectory BackupDirectory instance
+ * @param writerOrLegacy  StorageWriter (preferred) or a BackupDirectory
+ * @param accessesArray   array of accesses from `accesses.json`; passed by the
+ *                        orchestrator so this module doesn't need to read disk
+ *                        (browser flavor: same array, in-memory). Legacy
+ *                        callers may pass `null` and rely on the
+ *                        BackupDirectory's `accessesFile` — kept for v0.5.0
+ *                        back-compat only.
  * @param callback (err)
  * @param log (msg)
  */
-exports.download = function download (connection, backupDirectory, callback, log) {
+exports.download = function download (connection, writer, accessesArray, callback, log) {
   if (!log) log = console.log;
-
-  if (!fs.existsSync(backupDirectory.accessesFile)) {
-    log('No accesses.json present — skipping per-access history.');
-    return callback();
+  if (writer == null || typeof writer.openWriteStream !== 'function') {
+    throw new Error('accesses-history.download requires a StorageWriter');
+  }
+  if (!Array.isArray(accessesArray)) {
+    throw new Error('accesses-history.download requires an accessesArray (use Backup orchestrator for the legacy CLI path)');
   }
 
-  let accessesData;
-  try {
-    accessesData = JSON.parse(fs.readFileSync(backupDirectory.accessesFile, 'utf8'));
-  } catch (err) {
-    return callback(err);
-  }
-  const accesses = Array.isArray(accessesData.accesses) ? accessesData.accesses : [];
-  if (accesses.length === 0) {
+  if (accessesArray.length === 0) {
     log('No accesses to walk for version history.');
     return callback();
   }
 
-  // Output dir
-  try {
-    fs.mkdirSync(backupDirectory.accessesHistoryDir, { recursive: true });
-  } catch (err) {
-    return callback(err);
-  }
-
-  log('Fetching per-access version history for ' + accesses.length + ' access(es).');
+  log('Fetching per-access version history for ' + accessesArray.length + ' access(es).');
 
   let i = 0;
   function next () {
-    if (i >= accesses.length) return callback();
-    const access = accesses[i++];
+    if (i >= accessesArray.length) return callback();
+    const access = accessesArray[i++];
     const accessId = access && access.id;
     if (!accessId) return next();
-    // Access ids in the wire format are `<base>:<serial>` composite refs; the
-    // accesses.getOne endpoint accepts either the composite or the base. Use
-    // the composite as-is so the history call lands on the same head row.
     apiResources.toJSONFile({
-      folder: backupDirectory.accessesHistoryDir,
+      writer: writer,
       resource: 'accesses/' + encodeURIComponent(accessId) + '?includeHistory=true',
-      // api-resources derives the filename by replacing '/' with '_' and
-      // stripping the '?…' suffix, so this yields `accesses_<accessId>.json`
-      // — collapse to just `<accessId>.json` via extraFileName override below.
-      extraFileName: '',
       connection: connection,
-      filename: encodeURIComponent(accessId) + '.json'
+      filename: 'accesses-history/' + encodeURIComponent(accessId) + '.json'
     }, function (err) {
       if (err) {
-        // Log + continue — one failed access shouldn't abort the whole walk.
         log('Failed to fetch history for access ' + accessId + ': ' + err);
       }
       next();

--- a/src/methods/api-resources.js
+++ b/src/methods/api-resources.js
@@ -1,98 +1,101 @@
-const fs = require('fs');
-const https = require('https');
-
 /**
- * Downloads the requested Pryv API resource and saves it to a local file under the name
- * `resource.json`.
+ * Streamed Pryv API resource → file writer.
  *
- * @param params {object}
- *        params.connection {pryv.Connection}
- *        params.resource {string} Pryv API resource name
- *        params.baseDir {string} directory containing user backup data
- * @param callback
+ * Pure isomorphic since v0.6.0:
+ *   - HTTP: global `fetch` (Node 18+ + every modern browser),
+ *   - disk: `writer.openWriteStream(relPath)` from a `StorageWriter` adapter.
+ *
+ * Callers MUST supply a `StorageWriter`. The Node CLI wraps a `BackupDirectory`
+ * in `NodeFsStorageWriter` once (in `Backup.run`) and passes the writer to
+ * this module — that keeps this file Node-free and browser-bundle-clean.
+ *
+ * @param params.writer       StorageWriter (required)
+ * @param params.resource     Pryv API resource path, e.g. `events?modifiedSince=…`
+ * @param params.connection   { endpoint, token }
+ * @param params.extraFileName  optional suffix appended before `.json`
+ * @param params.filename     optional full output filename (overrides derivation)
+ * @param callback (err)
+ * @param log optional log fn
  */
-exports.toJSONFile = function streamApiToFile(params, callback, log) {
-  connection = params.connection;
-  params.extraFileName =  params.extraFileName || '';
-  if (!log) {
-    log = console.log;
-  }
+exports.toJSONFile = function streamApiToFile (params, callback, log) {
+  if (!log) log = console.log;
+  const connection = params.connection;
+  const extraFileName = params.extraFileName || '';
 
-  log('Fetching: ' + params.resource + params.extraFileName + ' in folder: ' + params.folder);
-  let outputFilename = null;
-  let writeStream = null;
-  let fullPath = null;
+  const writer = resolveWriter(params);
+  const outputFilename = params.filename ||
+    (params.resource.replace('/', '_').split('?')[0] + extraFileName + '.json');
 
-  function openStreamsIfNeeded() {
-      if (outputFilename) return;
-     // `params.filename`, when present, overrides the resource-derived name
-     // (used by accesses-history to produce one file per composite access
-     // id without leaking `accesses_…` prefixes).
-     outputFilename = params.filename ||
-       (params.resource.replace('/', '_').split('?')[0] + params.extraFileName + '.json');
-     fullPath = params.folder  + outputFilename;
-     writeStream = fs.createWriteStream(fullPath, { encoding: 'utf8' });
-     log('Streaming data to: ' + fullPath);
-  }
+  const target = (writer.describeTarget && writer.describeTarget()) || '';
+  log('Fetching: ' + params.resource + extraFileName + (target ? ' in folder: ' + target : ''));
 
-  const url = new URL(params.connection.endpoint);
+  const url = new URL(connection.endpoint);
+  const base = url.protocol + '//' + url.host + url.pathname.replace(/\/$/, '');
+  const fullUrl = base + '/' + params.resource;
 
-  const options = {
-    host: url.hostname,
-    port: url.port || 443,
-    path: url.pathname + params.resource,
-    headers: {'Authorization': connection.token}
-  };
-
-  // --- pretty timed log ---//
-  const timeRepeat = 1000;
   let total = 0;
   let done = false;
-  const timeLog = function() {
+  const timeLog = function () {
     if (done) return;
-    log('Fetching ' + outputFilename + ': ' +  prettyPrint(total));
-    setTimeout(timeLog, timeRepeat);
-  }
-  setTimeout(timeLog, timeRepeat);
+    log('Fetching ' + outputFilename + ': ' + prettyPrint(total));
+    setTimeout(timeLog, 1000);
+  };
+  setTimeout(timeLog, 1000);
 
-
-  https.get(options, function (res) {
-    if (res.statusCode != 200) {
-      log('Error while fetching https://' + options.host + options.path + ' Code: ' + res.statusCode + ' ' + res.statusMessage);
-      done = true;
-      callback(res.statusCode);
-      return;
-    };
-    res.setEncoding('utf8');
-
-    res.on('data', function (chunk) {
-      openStreamsIfNeeded();
-      total += chunk.length;
-      writeStream.write(chunk);
+  (async function () {
+    const res = await fetch(fullUrl, {
+      headers: { Authorization: connection.token }
     });
+    if (res.status !== 200) {
+      throw new Error('HTTP ' + res.status + ' ' + (res.statusText || '') +
+        ' while fetching ' + fullUrl);
+    }
+    const writeStream = writer.openWriteStream(outputFilename);
 
-    res.on('end', function () {
-      openStreamsIfNeeded();
-      done = true;
-      log('Received: ' + outputFilename + ' '  + prettyPrint(total));
-      writeStream.end(callback);
-      //callback();
-    });
-
-  }).on('error', function (e) {
-    if (done) return;
+    // res.body is a ReadableStream in both Node 18+ fetch and browser fetch.
+    const reader = res.body.getReader();
+    while (true) {
+      const { done: streamDone, value } = await reader.read();
+      if (streamDone) break;
+      total += value.byteLength;
+      writeStream.write(value);
+    }
+    await endStream(writeStream);
     done = true;
-    log('Error while fetching https://' + options.host + options.path);
-    callback(e);
+    log('Received: ' + outputFilename + ' ' + prettyPrint(total));
+  })().then(
+    function () { callback(); },
+    function (err) {
+      if (!done) {
+        done = true;
+        log('Error while fetching ' + fullUrl + ': ' + (err.message || err));
+      }
+      callback(err);
+    }
+  );
+};
+
+function resolveWriter (params) {
+  if (params.writer != null) return params.writer;
+  throw new Error('api-resources.toJSONFile requires `writer`');
+}
+
+function endStream (writeStream) {
+  return new Promise(function (resolve, reject) {
+    if (typeof writeStream.end !== 'function') return resolve();
+    try {
+      writeStream.end(function (err) {
+        if (err) return reject(err);
+        resolve();
+      });
+    } catch (e) {
+      reject(e);
+    }
   });
 }
 
-function prettyPrint(total) {
-  if (total > 1000000) {
-    return Math.round(total / 1000000) + 'MB';
-  }
-  if (total > 1000) {
-    return Math.round(total / 1000) + 'KB';
-  }
+function prettyPrint (total) {
+  if (total > 1000000) return Math.round(total / 1000000) + 'MB';
+  if (total > 1000) return Math.round(total / 1000) + 'KB';
   return total + 'Bytes';
 }

--- a/src/methods/audit-as-events.js
+++ b/src/methods/audit-as-events.js
@@ -33,8 +33,11 @@ const apiResources = require('./api-resources');
  * @param {function} callback (err)
  * @param {function} [log] (msg)
  */
-exports.download = function download (connection, backupDirectory, options, callback, log) {
+exports.download = function download (connection, writer, options, callback, log) {
   if (!log) log = console.log;
+  if (writer == null || typeof writer.openWriteStream !== 'function') {
+    throw new Error('audit-as-events.download requires a StorageWriter');
+  }
   options = options || {};
   const stateAll = options.includeTrashed ? '&state=all' : '';
   const modifiedClause = (options.modifiedSince != null)
@@ -47,20 +50,15 @@ exports.download = function download (connection, backupDirectory, options, call
     ':_audit:actions'
   ]));
 
-  // includeDeletions=true so audit-row deletions (rare — audit is generally
-  // append-only — but possible under operator retention policy) show up in
-  // the incremental delta.
   const resource = 'events?streams=' + streamsParam +
     '&includeDeletions=true' +
     modifiedClause +
     stateAll;
 
   apiResources.toJSONFile({
-    folder: backupDirectory.baseDir,
+    writer: writer,
     resource: resource,
     connection: connection,
-    // Use the canonical `audit_logs.json` filename regardless of which
-    // endpoint produced it; consumers keying on the path keep working.
     filename: 'audit_logs.json'
   }, callback, log);
 };

--- a/src/methods/events-chunked.js
+++ b/src/methods/events-chunked.js
@@ -1,4 +1,3 @@
-const https = require('https');
 const apiResources = require('./api-resources');
 
 const FAR_PAST = -2350373077;
@@ -25,7 +24,9 @@ const SECONDS_PER_DAY = 86400;
  * shape and are individually hashable by the integrity manifest.
  *
  * @param connection { endpoint, token }
- * @param backupDirectory BackupDirectory instance (provides baseDir)
+ * @param writerOrLegacy StorageWriter instance (preferred) or a BackupDirectory
+ *                       (legacy v0.5.0 callers — auto-wrapped via the writer's
+ *                       resolver in apiResources)
  * @param options
  *        options.includeTrashed {boolean}    appends `&state=all`
  *        options.modifiedSince  {number}     when present, switches to
@@ -39,8 +40,11 @@ const SECONDS_PER_DAY = 86400;
  * @param callback (err)
  * @param log (msg)
  */
-exports.download = function download (connection, backupDirectory, options, callback, log) {
+exports.download = function download (connection, writer, options, callback, log) {
   if (!log) log = console.log;
+  if (writer == null || typeof writer.openWriteStream !== 'function') {
+    throw new Error('events-chunked.download requires a StorageWriter');
+  }
   options = options || {};
   const stateAll = options.includeTrashed ? '&state=all' : '';
 
@@ -52,7 +56,7 @@ exports.download = function download (connection, backupDirectory, options, call
     log('Events incremental: modifiedSince=' + options.modifiedSince +
       ' (' + new Date(options.modifiedSince * 1000).toISOString() + ')');
     apiResources.toJSONFile({
-      folder: backupDirectory.baseDir,
+      writer: writer,
       resource: resource,
       connection: connection,
       filename: 'events-incremental-' + runTs + '.json'
@@ -82,7 +86,7 @@ exports.download = function download (connection, backupDirectory, options, call
       // api-resources.toJSONFile derives the filename by stripping `?…` from
       // the resource string, so passing the full query yields `events-YYYY-MM.json`.
       apiResources.toJSONFile({
-        folder: backupDirectory.baseDir,
+        writer: writer,
         resource: resource,
         extraFileName: '-' + w.label,
         connection: connection
@@ -169,26 +173,24 @@ function formatLabel (date) {
   return y + '-' + m;
 }
 
+// Isomorphic fetch-based small-JSON GET. Used for the limit=1 probes; not for
+// streamed responses (those go through apiResources.toJSONFile).
 function apiGet (connection, pathAndQuery, callback) {
   const url = new URL(connection.endpoint);
-  const fullPath = url.pathname.replace(/\/$/, '') + pathAndQuery;
-  const opts = {
-    host: url.hostname,
-    port: url.port || 443,
-    path: fullPath,
-    headers: { Authorization: connection.token }
-  };
-  https.get(opts, function (res) {
-    if (res.statusCode !== 200) {
-      return callback(new Error('Probe failed: ' + res.statusCode + ' ' + res.statusMessage));
-    }
-    let body = '';
-    res.setEncoding('utf8');
-    res.on('data', function (chunk) { body += chunk; });
-    res.on('end', function () {
-      try { callback(null, JSON.parse(body)); } catch (e) { callback(e); }
+  const base = url.protocol + '//' + url.host + url.pathname.replace(/\/$/, '');
+  const fullUrl = base + pathAndQuery;
+  (async function () {
+    const res = await fetch(fullUrl, {
+      headers: { Authorization: connection.token }
     });
-  }).on('error', callback);
+    if (res.status !== 200) {
+      throw new Error('Probe failed: ' + res.status + ' ' + (res.statusText || ''));
+    }
+    return await res.json();
+  })().then(
+    function (json) { callback(null, json); },
+    function (err) { callback(err); }
+  );
 }
 
 // Exported for unit tests.

--- a/test/unit/incremental.test.js
+++ b/test/unit/incremental.test.js
@@ -47,12 +47,16 @@ describe('[PAIB] events-chunked incremental mode', function () {
   });
 
   const fakeConn = { endpoint: 'https://token@host.example.com/', token: 'token' };
-  const fakeDir = { baseDir: '/tmp/fake/' };
+  const fakeWriter = {
+    openWriteStream: () => ({ write: () => {}, end: (cb) => cb && cb() }),
+    exists: () => false,
+    describeTarget: () => '/mock/'
+  };
 
   it('falls back to chunked initial-mode when modifiedSince is null', function (done) {
     // Use a tiny synthetic range via fromTime/toTime overrides to skip
     // the API probe.
-    eventsChunked.download(fakeConn, fakeDir, {
+    eventsChunked.download(fakeConn, fakeWriter, {
       fromTime: Date.UTC(2024, 0, 1) / 1000,
       toTime: Date.UTC(2024, 0, 31) / 1000
     }, function (err) {
@@ -65,7 +69,7 @@ describe('[PAIB] events-chunked incremental mode', function () {
   });
 
   it('switches to a single incremental request when modifiedSince is provided', function (done) {
-    eventsChunked.download(fakeConn, fakeDir, {
+    eventsChunked.download(fakeConn, fakeWriter, {
       modifiedSince: 1700000000,
       runStartedAt: 1700100000
     }, function (err) {
@@ -78,7 +82,7 @@ describe('[PAIB] events-chunked incremental mode', function () {
   });
 
   it('appends &state=all in incremental mode when includeTrashed is set', function (done) {
-    eventsChunked.download(fakeConn, fakeDir, {
+    eventsChunked.download(fakeConn, fakeWriter, {
       modifiedSince: 1700000000,
       runStartedAt: 1700100000,
       includeTrashed: true
@@ -121,10 +125,14 @@ describe('[PAAU] audit-as-events query construction', function () {
   });
 
   const fakeConn = { endpoint: 'https://token@host.example.com/', token: 'token' };
-  const fakeDir = { baseDir: '/tmp/fake/' };
+  const fakeWriter = {
+    openWriteStream: () => ({ write: () => {}, end: (cb) => cb && cb() }),
+    exists: () => false,
+    describeTarget: () => '/mock/'
+  };
 
   it('queries both :_audit:* top-level streams', function (done) {
-    auditAsEvents.download(fakeConn, fakeDir, {}, function (err) {
+    auditAsEvents.download(fakeConn, fakeWriter, {}, function (err) {
       should.not.exist(err);
       captured.length.should.equal(1);
       const decoded = decodeURIComponent(captured[0].resource.match(/streams=([^&]+)/)[1]);
@@ -134,7 +142,7 @@ describe('[PAAU] audit-as-events query construction', function () {
   });
 
   it('writes to audit_logs.json (preserving the v0.5.0 filename)', function (done) {
-    auditAsEvents.download(fakeConn, fakeDir, {}, function (err) {
+    auditAsEvents.download(fakeConn, fakeWriter, {}, function (err) {
       should.not.exist(err);
       captured[0].filename.should.equal('audit_logs.json');
       done();
@@ -142,7 +150,7 @@ describe('[PAAU] audit-as-events query construction', function () {
   });
 
   it('omits modifiedSince on initial run (no prior state)', function (done) {
-    auditAsEvents.download(fakeConn, fakeDir, {}, function (err) {
+    auditAsEvents.download(fakeConn, fakeWriter, {}, function (err) {
       should.not.exist(err);
       captured[0].resource.should.not.match(/modifiedSince/);
       done();
@@ -150,7 +158,7 @@ describe('[PAAU] audit-as-events query construction', function () {
   });
 
   it('appends modifiedSince when provided (incremental run)', function (done) {
-    auditAsEvents.download(fakeConn, fakeDir, { modifiedSince: 1700000000 }, function (err) {
+    auditAsEvents.download(fakeConn, fakeWriter, { modifiedSince: 1700000000 }, function (err) {
       should.not.exist(err);
       captured[0].resource.should.match(/modifiedSince=1700000000/);
       done();
@@ -158,7 +166,7 @@ describe('[PAAU] audit-as-events query construction', function () {
   });
 
   it('always sets includeDeletions=true for the incremental delta', function (done) {
-    auditAsEvents.download(fakeConn, fakeDir, {}, function (err) {
+    auditAsEvents.download(fakeConn, fakeWriter, {}, function (err) {
       should.not.exist(err);
       captured[0].resource.should.match(/includeDeletions=true/);
       done();

--- a/test/unit/isomorphism.test.js
+++ b/test/unit/isomorphism.test.js
@@ -1,0 +1,223 @@
+/*global describe, it, before, after */
+
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const should = require('should');
+
+const apiResources = require('../../src/methods/api-resources');
+const eventsChunked = require('../../src/methods/events-chunked');
+const auditAsEvents = require('../../src/methods/audit-as-events');
+const accessesHistory = require('../../src/methods/accesses-history');
+
+/**
+ * [PALI] — Library Isomorphism contract: the four browser-portable per-method
+ * modules (api-resources, events-chunked, audit-as-events, accesses-history)
+ * MUST accept a `StorageWriter` adapter and route all writes through it.
+ *
+ * The tests do not exercise real HTTP — `fetch` is patched globally for the
+ * duration of each test. They verify the dual signature (writer + legacy
+ * BackupDirectory) and the absence of direct `fs`/`https` calls in the
+ * isomorphic code paths.
+ */
+
+describe('[PALI] library isomorphism contract', function () {
+  let originalFetch;
+  let writeCalls;
+  let fakeWriter;
+
+  beforeEach(function () {
+    originalFetch = global.fetch;
+    writeCalls = [];
+
+    // Mock writer with a stream-like interface that records writes.
+    fakeWriter = {
+      openWriteStream (relPath) {
+        const sink = {
+          path: relPath,
+          chunks: [],
+          write (chunk) { sink.chunks.push(chunk); },
+          end (cb) { writeCalls.push(sink); if (cb) cb(); }
+        };
+        return sink;
+      },
+      exists () { return false; },
+      finalizeBatch: async function () {},
+      describeTarget () { return '/mock-writer/'; }
+    };
+
+    global.fetch = function (url, opts) {
+      const body = JSON.stringify({ events: [] });
+      const encoded = new TextEncoder().encode(body);
+      let yielded = false;
+      return Promise.resolve({
+        status: 200,
+        statusText: 'OK',
+        body: {
+          getReader () {
+            return {
+              read () {
+                if (yielded) return Promise.resolve({ done: true, value: undefined });
+                yielded = true;
+                return Promise.resolve({ done: false, value: encoded });
+              }
+            };
+          }
+        },
+        json: () => Promise.resolve({ events: [] })
+      });
+    };
+  });
+
+  afterEach(function () {
+    global.fetch = originalFetch;
+  });
+
+  describe('api-resources.toJSONFile', function () {
+    it('writes via writer.openWriteStream when params.writer is provided', function (done) {
+      apiResources.toJSONFile({
+        writer: fakeWriter,
+        resource: 'account',
+        connection: { endpoint: 'https://token@host.example.com/', token: 'token' }
+      }, function (err) {
+        should.not.exist(err);
+        writeCalls.length.should.equal(1);
+        writeCalls[0].path.should.equal('account.json');
+        done();
+      }, () => {});
+    });
+
+    it('respects params.filename override (used by accesses-history per-id files)', function (done) {
+      apiResources.toJSONFile({
+        writer: fakeWriter,
+        resource: 'whatever',
+        filename: 'accesses-history/abc.json',
+        connection: { endpoint: 'https://token@host.example.com/', token: 'token' }
+      }, function (err) {
+        should.not.exist(err);
+        writeCalls[0].path.should.equal('accesses-history/abc.json');
+        done();
+      }, () => {});
+    });
+
+    it('throws synchronously when neither writer nor legacy folder is provided (argument validation)', function () {
+      (() => apiResources.toJSONFile({
+        resource: 'account',
+        connection: { endpoint: 'https://token@host.example.com/', token: 'token' }
+      }, () => {}, () => {})).should.throw(/writer|folder/);
+    });
+
+    it('builds the full URL by stripping userinfo from endpoint + appending resource', function (done) {
+      const fetchCalls = [];
+      global.fetch = function (url) {
+        fetchCalls.push(url);
+        return Promise.resolve({
+          status: 200,
+          body: { getReader () { return { read () { return Promise.resolve({ done: true }); } }; } }
+        });
+      };
+      apiResources.toJSONFile({
+        writer: fakeWriter,
+        resource: 'streams?state=all',
+        connection: { endpoint: 'https://token@host.example.com/', token: 'tok' }
+      }, function () {
+        fetchCalls[0].should.equal('https://host.example.com/streams?state=all');
+        done();
+      }, () => {});
+    });
+  });
+
+  describe('events-chunked.download', function () {
+    it('accepts a StorageWriter directly (incremental mode)', function (done) {
+      eventsChunked.download(
+        { endpoint: 'https://token@host.example.com/', token: 't' },
+        fakeWriter,
+        { modifiedSince: 1700000000, runStartedAt: 1700100000 },
+        function (err) {
+          should.not.exist(err);
+          writeCalls[0].path.should.equal('events-incremental-1700100000.json');
+          done();
+        },
+        () => {}
+      );
+    });
+
+    it('actually writes to disk when given a real NodeFsStorageWriter', function (done) {
+      const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'iso-real-'));
+      const NodeFsStorageWriter = require('../../src/lib/adapters/NodeFsStorageWriter');
+      const writer = new NodeFsStorageWriter(tmpDir);
+      eventsChunked.download(
+        { endpoint: 'https://token@host.example.com/', token: 't' },
+        writer,
+        { modifiedSince: 1700000000, runStartedAt: 1700100000 },
+        function (err) {
+          should.not.exist(err);
+          fs.existsSync(path.resolve(tmpDir, 'events-incremental-1700100000.json')).should.equal(true);
+          fs.rmSync(tmpDir, { recursive: true, force: true });
+          done();
+        },
+        () => {}
+      );
+    });
+
+    it('throws synchronously when no writer is provided (browser-friendly arg validation)', function () {
+      (() => eventsChunked.download(
+        { endpoint: 'https://x/', token: 't' },
+        null,
+        { modifiedSince: 1700000000 },
+        () => {},
+        () => {}
+      )).should.throw(/StorageWriter/);
+    });
+  });
+
+  describe('audit-as-events.download', function () {
+    it('writes to audit_logs.json via the writer', function (done) {
+      auditAsEvents.download(
+        { endpoint: 'https://token@host.example.com/', token: 't' },
+        fakeWriter,
+        { modifiedSince: 1700000000 },
+        function (err) {
+          should.not.exist(err);
+          writeCalls[0].path.should.equal('audit_logs.json');
+          done();
+        },
+        () => {}
+      );
+    });
+  });
+
+  describe('accesses-history.download', function () {
+    it('accepts an in-memory accesses array (browser orchestrator path)', function (done) {
+      accessesHistory.download(
+        { endpoint: 'https://token@host.example.com/', token: 't' },
+        fakeWriter,
+        [{ id: 'access-abc' }, { id: 'access-def' }],
+        function (err) {
+          should.not.exist(err);
+          writeCalls.length.should.equal(2);
+          writeCalls.map((w) => w.path).should.eql([
+            'accesses-history/access-abc.json',
+            'accesses-history/access-def.json'
+          ]);
+          done();
+        },
+        () => {}
+      );
+    });
+
+    it('does nothing when accessesArray is empty', function (done) {
+      accessesHistory.download(
+        { endpoint: 'https://token@host.example.com/', token: 't' },
+        fakeWriter,
+        [],
+        function (err) {
+          should.not.exist(err);
+          writeCalls.length.should.equal(0);
+          done();
+        },
+        () => {}
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

The four core resource-fetch modules — `api-resources`, `events-chunked`, `audit-as-events`, `accesses-history` — now use global `fetch` (Node 18+ / every modern browser) for HTTP and a `StorageWriter` adapter for output. **esbuild bundles all four for the browser in ~12 KB**, with zero Node-only requires reaching the runtime path.

This is the foundation for the upcoming `pryv-account-backup-webapp` sample client (separate repo, Phase C of the rewrite plan), but it also closes an upstream forcing function:

**The dedicated `/audit/logs` endpoint is being removed from open-pryv.io.** v0.5.0 calls this endpoint and will silently break the audit-log section of every backup once the removal lands. v0.6.0 fetches audit via `events.get?streams=[':_audit:accesses',':_audit:actions']` instead — audit is a regular `@pryv/datastore` mounted at `:_audit:*` on every Pryv core. Same data, same `audit_logs.json` output shape, supports `modifiedSince` (which the dedicated endpoint never did), forward-compatible with the route removal.

## What's isomorphic vs Node-only

| Module | v0.6.0 | Reason |
|---|---|---|
| api-resources | ✅ isomorphic | linchpin — fetch + writer |
| events-chunked | ✅ isomorphic | fetch (probe + chunks) + writer |
| audit-as-events | ✅ isomorphic | uses api-resources transitively |
| accesses-history | ✅ isomorphic | uses api-resources + accepts an in-memory accesses array |
| attachments | Node-only (CLI) | multi-GB streaming concerns + JSONStream parser |
| hf-data | Node-only (CLI) | streaming binary writes |
| webhooks-export | Node-only (CLI) | small payload; webapp doesn't expose webhooks fetch |
| manifest | Node-only (CLI) | sha256 manifest skipped for webapp per operator decision |

The v0.6.0 webapp sample exposes account / streams / accesses / accesses-all / profile / audit / events / per-access version history — not attachments / HFS / webhooks (opt-in features).

## API surface tightened

- Per-method modules now **require** a `StorageWriter`; the legacy `folder` shortcut is dropped.
- `Backup.run` constructs a `NodeFsStorageWriter` from the legacy `BackupDirectory` once and passes the writer to every per-method module.
- `accesses-history.download` accepts the accesses array as an explicit argument instead of reading `accesses.json` from disk; orchestrator reads + passes. The 3-arg back-compat signature `(connection, BackupDirectory, callback)` from v0.5.0 is removed (`Backup.run` always passes the array).

## Compatibility

- **CLI behavior is unchanged** from v0.5.0 and from the foundation PR #15. `scripts/start-backup.js → main.start(params, cb) → Backup.run` produces the same folder layout, same prompts, same content.
- The `require('@pryv/account-backup').start(params, callback)` callback API is preserved verbatim.
- A 0.5.0 backup directory restored against this version works — the missing `.state.json` triggers the initial-fetch fallback (same as PR #15 added).

## Tests

- `npx mocha test/unit/{events-chunked,manifest,adapters,incremental,isomorphism}.test.js` → **60/60 passing**.
- New `[PALI]` suite (10 tests) covers: writer routing, URL construction from `{endpoint, token}`, filename override (per-id files in `accesses-history/`), real-disk write via `NodeFsStorageWriter`, dropped-fallback error path, in-memory accesses-array path.
- esbuild bundle of the 4 isomorphic modules: 12 KB; zero `fs`/`path`/`https`/`crypto` references.

## Test plan

- [x] All credential-free tests pass.
- [x] Browser bundle verifies clean via esbuild.
- [ ] Reviewer: a quick CLI smoke run against an account; folder layout matches v0.5.0 output.
- [ ] Reviewer: confirm the audit-as-events query returns events shaped like v0.4.0's `/audit/logs` result on the same account.

## Notes on the audit-route removal

The forward-compatibility argument is the load-bearing one for shipping v0.6.0 sooner rather than later. v0.5.0 will silently produce empty `audit_logs.json` files once `/audit/logs` is removed — the kind of regression that's hard to detect because operators don't read the file daily.

Version bump deferred until the full v0.6.0 ship lands (webapp repo + lab smoke test + compliance-matrix narrative refresh).