### PR TITLE
docs: /audit/logs route REMOVED upstream (past tense + 19d1c11f reference)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ Per-user run output (CLI, in a folder; webapp, across N ZIP files):
 | `accesses-all.json` | `GET /accesses?includeDeletions=true&includeExpired=true` | full disclosure-history view |
 | `profile_private.json` / `profile_public.json` | `GET /profile/{private,public}` | includes `profile.mfa.{content,recoveryCodes}` when MFA enabled |
 | `app_profiles/profile_app_<accessId>.json` | per-app `GET /profile/app` with each app token | |
-| `audit_logs.json` | **`GET /events?streams=[':_audit:accesses',':_audit:actions']&modifiedSince=T`** (v0.6.0+) — was `/audit/logs` in v0.4.0–v0.5.0 | audit is a regular `@pryv/datastore` mounted at `:_audit:*` on every Pryv core; the dedicated `/audit/logs` route is being removed upstream |
+| `audit_logs.json` | **`GET /events?streams=[':_audit:accesses',':_audit:actions']&modifiedSince=T`** (v0.6.0+) — was `/audit/logs` in v0.4.0–v0.5.0 | audit is a regular `@pryv/datastore` mounted at `:_audit:*` on every Pryv core; the dedicated `/audit/logs` route was **removed** from open-pryv.io on 2026-06-15 (commit `19d1c11f`), so v0.5.0 and earlier are now production-broken for the audit-log section against any deployment running that build |
 | `events-YYYY-MM.json` | `GET /events?fromTime=…&toTime=…` per monthly chunk (initial run) | preserves the v0.5.0 chunking story for first runs |
 | `events-incremental-<TS>.json` | `GET /events?modifiedSince=T&includeDeletions=true` (subsequent runs) | only events with `modified > T`; deletions included |
 | `accesses-history/<accessId>.json` | per-access `GET /accesses/<id>?includeHistory=true` (opt-in) | O(N) calls; opt-in via CLI prompt or `params.includeAccessHistory` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 Architectural rewrite around a programmatic library API (`require('@pryv/account-backup').Backup`) consuming pluggable adapters (`StorageWriter` + `StateStore`). The core resource-fetch modules are browser-isomorphic — `fetch` for HTTP, `StorageWriter.openWriteStream` for output. The CLI is preserved as a thin shim; behavior is byte-identical to 0.5.0 on a first run against a fresh backup directory. A sibling `pryv-account-backup-webapp` repository ships the browser-side adapter pair + sample UI.
 
-**Upstream context driving v0.6.0:** the dedicated `/audit/logs` endpoint is being removed from open-pryv.io. v0.5.0 calls this endpoint and will fail once the removal lands. v0.6.0 fetches audit via `events.get?streams=[':_audit:accesses',':_audit:actions']` instead — audit is a regular `@pryv/datastore` mounted at `:_audit:*` on every Pryv core. This route is forward-compatible with the removal AND supports `modifiedSince`, which the dedicated endpoint does not.
+**Upstream context driving v0.6.0:** the dedicated `/audit/logs` endpoint was **removed** from open-pryv.io on 2026-06-15 (commit `19d1c11f`). v0.5.0 calls this endpoint directly and is now production-broken for the audit-log section against any deployment running that build. v0.6.0 fetches audit via `events.get?streams=[':_audit:accesses',':_audit:actions']` instead — audit is a regular `@pryv/datastore` mounted at `:_audit:*` on every Pryv core. This route continues to work post-removal AND supports `modifiedSince`, which the dedicated endpoint never did.
 
 ### Added
 


### PR DESCRIPTION
Trivial doc update — the upstream removal landed today at open-pryv.io commit 19d1c11f. The CHANGELOG + AGENTS.md previously said 'is being removed' / 'route is being removed upstream'; now they reflect the landed reality. v0.5.0 is now production-broken against deployments running the post-removal build; v0.6.0 (this codebase) continues to work via the :_audit:* event-streams route.