### PR TITLE
fix(cli): attachments multi-file iteration + webhooks http/https flexibility (Phase F smoke catches)

### DIFF
--- a/src/methods/attachments.js
+++ b/src/methods/attachments.js
@@ -65,8 +65,22 @@ function loadStreamMapIfNeed(backupDir, log) {
 }
 
 function loadEventFile(connection, backupDir, callback, log) {
+  // Walk every event-data file the backup carries — legacy single-file
+  // `events.json` (older backups) and chunked `events-YYYY-MM.json` (0.5.0+)
+  // and incremental `events-incremental-<TS>.json` (0.6.0+). Prior to this
+  // fix, only the legacy file was streamed; chunked-only backups crashed
+  // immediately with `ENOENT events.json` when `--includeAttachments` was
+  // on — the same regression pattern as the 0.6.0 hf-data fix.
+  const eventFiles = (typeof backupDir.listEventFiles === 'function')
+    ? backupDir.listEventFiles()
+    : (fs.existsSync(backupDir.eventsFile) ? [backupDir.eventsFile] : []);
+  if (eventFiles.length === 0) {
+    log('attachments: skipping (no events-*.json files — events fetch must run first)');
+    return callback(null, []);
+  }
+
   const attachments = [];
-  log('Parsing events for attachments');
+  log('Parsing events for attachments across ' + eventFiles.length + ' file(s)');
 
   // --- pretty timed log ---//
   const timeRepeat = 1000;
@@ -79,29 +93,35 @@ function loadEventFile(connection, backupDir, callback, log) {
   }
   setTimeout(timeLog, timeRepeat);
 
-  fs.createReadStream(backupDir.eventsFile, 'utf8').pipe(
-    JSONStream.parse('events.*').on('data', function(event) {
-      total++;
-      if (event.attachments) {
-        event.attachments.forEach(function (att) {
-          if (att.id) {
-            att.eventId = event.id;
-            att.streamId = event.streamId;
-            attachments.push(att);
-          } else {
-            log('Invalid event: att.id is missing: ' + event);
-          }
-        });
-      }
-  }).on('error', function(error) {
-      done = true;
-      log('Error while fetching attachments: ' + error)
-      callback(error, attachments);
-    }).on('end', function() {
+  function streamOne (i) {
+    if (i >= eventFiles.length) {
       done = true;
       log('Found ' + attachments.length + ' attachments');
-      callback(null, attachments);
-    }));
+      return callback(null, attachments);
+    }
+    fs.createReadStream(eventFiles[i], 'utf8').pipe(
+      JSONStream.parse('events.*').on('data', function(event) {
+        total++;
+        if (event.attachments) {
+          event.attachments.forEach(function (att) {
+            if (att.id) {
+              att.eventId = event.id;
+              att.streamId = event.streamId;
+              attachments.push(att);
+            } else {
+              log('Invalid event: att.id is missing: ' + event);
+            }
+          });
+        }
+      }).on('error', function(error) {
+        done = true;
+        log('Error while fetching attachments: ' + error);
+        callback(error, attachments);
+      }).on('end', function() {
+        streamOne(i + 1);
+      }));
+  }
+  streamOne(0);
 }
 
 

--- a/src/methods/webhooks-export.js
+++ b/src/methods/webhooks-export.js
@@ -83,14 +83,18 @@ function writeOutput (backupDir, accessesScanned, webhooks, log, callback) {
 }
 
 function fetchWebhooksForAccess (apiUrl, access, log, callback) {
+  // Pick http or https based on the apiEndpoint scheme — required for
+  // dev / lab deployments that run HTTP-only (the QuickStart on mbp2,
+  // CI fixtures, etc.). Production always uses https.
+  const transport = apiUrl.protocol === 'http:' ? require('http') : https;
   const options = {
     host: apiUrl.hostname,
-    port: apiUrl.port || 443,
+    port: apiUrl.port || (apiUrl.protocol === 'http:' ? 80 : 443),
     path: apiUrl.pathname + 'webhooks',
     headers: { Authorization: access.token }
   };
   const chunks = [];
-  https.get(options, function (res) {
+  transport.get(options, function (res) {
     if (res.statusCode === 401 || res.statusCode === 403) {
       // Expected for expired tokens — skip silently.
       log('webhooks-export: access ' + access.id + ' rejected (HTTP ' + res.statusCode + '), skipping');


### PR DESCRIPTION
Two regressions caught by running the v0.6.0 CLI end-to-end against a fresh open-pryv.io v2.0.0-pre.4 QuickStart instance with a seeded test account.

**attachments.js** — same pattern as the v0.6.0 hf-data fix (PR #15). Pre-fix the module streamed only the legacy events.json; on any chunked or incremental backup the file was absent and the CLI crashed immediately with ENOENT the moment --includeAttachments was on. Fix: walk backupDir.listEventFiles() and stream each event-data file in sequence.

**webhooks-export.js** — hardcoded https.get() failed with EPROTO/SSL against any HTTP-only deployment (mbp2 QuickStart, CI fixtures, local dev). Fix: pick http or https module from apiUrl.protocol.

Verified by running the [PAAU]/[PAIB]/[PAHF] smoke twice against mbp2 QuickStart — all green, no crashes, attachments + webhooks fetchers iterate cleanly across all event files / all access endpoints.