### PR TITLE
v0.7.0: attachments / HFS / webhooks browser-isomorphic + portable sync-state.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,7 @@ This repo is the **library + CLI** for end-user-driven Pryv account backup. The 
 A single tool with two consumption modes:
 
 - **CLI** — `npm install && npm start` (the historical entry point; behavior is preserved through every release).
-- **Library** — `require('@pryv/account-backup')` exposes `Backup` + adapter interfaces (`StorageWriter`, `StateStore`) + CLI implementations (`NodeFsStorageWriter`, `FolderStateStore`). The browser webapp consumes the **browser-isomorphic** per-method modules directly (`api-resources`, `events-chunked`, `audit-as-events`, `accesses-history`); the Node-only modules (`attachments`, `hf-data`, `webhooks-export`, `manifest`) stay CLI-only.
+- **Library** — `require('@pryv/account-backup')` exposes `Backup` + adapter interfaces (`StorageWriter`, `StateStore`) + CLI implementations (`NodeFsStorageWriter`, `FolderStateStore`). Seven per-method modules are **browser-isomorphic** since v0.7.0 (`api-resources`, `events-chunked`, `audit-as-events`, `accesses-history`, `attachments`, `hf-data`, `webhooks-export`); the only Node-only module is `manifest` (sha256 stays CLI-only).
 
 The tool produces a portable account dump suitable for GDPR Art.15 / Art.20, CCPA §1798.110 / §1798.115, PIPEDA Principle 4.9, Swiss nLPD Art.25, HIPAA-privacy §164.524 disclosure requests.
 
@@ -27,39 +27,68 @@ Per-user run output (CLI, in a folder; webapp, across N ZIP files):
 | `events-YYYY-MM.json` | `GET /events?fromTime=…&toTime=…` per monthly chunk (initial run) | preserves the v0.5.0 chunking story for first runs |
 | `events-incremental-<TS>.json` | `GET /events?modifiedSince=T&includeDeletions=true` (subsequent runs) | only events with `modified > T`; deletions included |
 | `accesses-history/<accessId>.json` | per-access `GET /accesses/<id>?includeHistory=true` (opt-in) | O(N) calls; opt-in via CLI prompt or `params.includeAccessHistory` |
-| `attachments/<eventId>_<filename>` | per-attachment `GET /events/<id>/<attId>` (opt-in, **CLI only**) | streamed binary; webapp does not expose attachments |
-| `hf-data/<eventId>.json` | per `series:*` event `GET /events/<id>/series` (**CLI only**) | HFS data points |
-| `webhooks.json` | per-access `GET /webhooks` (**CLI only**) | aggregated by `accessId` |
+| `attachments/<eventId>_<fileName>` | per-attachment `GET /events/<id>/<attId>?readToken=…` (opt-in) | streamed binary; both CLI + webapp |
+| `hf-data/<eventId>.json` | per `series:*` event `GET /events/<id>/series` (opt-in) | HFS data points; both CLI + webapp |
+| `webhooks.json` | per-access `GET /webhooks` (opt-in) | aggregated by `accessId`; both CLI + webapp |
 | `manifest.json` | sha256 per file (**CLI only**) | tamper-evidence; webapp does not generate this |
-| `.state.json` (CLI) / `localStorage` (webapp) | `lastRunAt` + per-resource `lastModifiedSince` + tool/format version | drives incremental fetch on the next run |
+| `sync-state.json` | portable kv snapshot of `lastRunAt` + per-resource `lastModifiedSince` + tool/format version | both CLI + webapp (v0.7.0+); subject downloads + re-uploads to drive cross-session incremental in the browser |
+| `.sync-state.json` (CLI, hidden) / `localStorage` (webapp) | operational store: kv state + per-category work refs (`attachment`, `series-event`, `webhook`) discovered during one run | refs are pruned at run-end; only kv goes into the portable `sync-state.json` |
 
 ## Architecture
 
 ```
 src/lib/
-├── Backup.js                  ← orchestrator (Node CLI; coordinates per-method modules)
+├── Backup.js                  ← orchestrator (coordinates per-method modules; wires onParsed
+│                                tee → state.pushRef; drains refs through per-category drainers)
 ├── index.js                   ← library entry: Backup + adapters
 └── adapters/
     ├── StorageWriter.js       ← abstract: openWriteStream / exists / finalizeBatch
-    ├── StateStore.js          ← abstract: get / set / getAll / flush
+    ├── StateStore.js          ← abstract: kv (get / set / getAll / flush)
+    │                            + refs (pushRef / listPending / markDone / clearCategory)
+    │                            + portable (export / import)
     ├── NodeFsStorageWriter.js ← writes to disk; back-compat with BackupDirectory
-    └── FolderStateStore.js    ← .state.json sentinel in baseDir
+    └── FolderStateStore.js    ← .sync-state.json sentinel in baseDir; auto-migrates from .state.json
 
-src/methods/                   ← per-resource fetchers
-├── api-resources.js           ← isomorphic (fetch + writer)
-├── events-chunked.js          ← isomorphic
-├── audit-as-events.js         ← isomorphic
-├── accesses-history.js        ← isomorphic
-├── attachments.js             ← Node-only (multi-GB streaming)
-├── hf-data.js                 ← Node-only (binary streaming)
-├── webhooks-export.js         ← Node-only
-└── manifest.js                ← Node-only (sha256)
+src/methods/                   ← per-resource fetchers (all browser-isomorphic except manifest)
+├── api-resources.js           ← fetch + writer; opt-in onParsed(doc) tee
+├── events-chunked.js          ← chunked initial / single incremental; onEvents(events[]) lift
+├── audit-as-events.js         ← :_audit:* streams via events.get
+├── accesses-history.js        ← per-access version history (in-memory array)
+├── attachments.js             ← drains 'attachment' refs; binary stream pipe
+├── hf-data.js                 ← drains 'series-event' refs; data-points fetch
+├── webhooks-export.js         ← drains 'webhook' refs; per-access /webhooks
+└── manifest.js                ← Node-only (sha256 tamper-evidence)
 
 scripts/
 ├── start-backup.js            ← CLI entry (interactive prompts)
 └── start-restore.js           ← CLI restore (experimental, deliberately limited)
 
 src/restore.js                 ← restore-side logic (CLI only; library does NOT export restore)
+```
+
+## Ref-tracking flow (v0.7.0+)
+
+```
+            ┌──────────────────────────────────────────────┐
+fetch step  │  api-resources.toJSONFile({ onParsed: ... }) │
+            │  events-chunked.download({ onEvents: ... })  │
+            └──────────────┬───────────────────────────────┘
+                           │  parsed doc
+                           ▼
+                ┌──────────────────────┐
+   orchestrator│ state.pushRef(cat,r)  │
+                └──────────┬───────────┘
+                           │
+                           ▼
+              .sync-state.json (Node) / localStorage (browser)
+                           │
+                           │  state.listPending(cat) →
+                           ▼
+                ┌──────────────────────┐
+drain step      │ attachments.download │  fetch + write + markDone
+                │   / hf-data.download │
+                │ / webhooks.download  │
+                └──────────────────────┘
 ```
 
 ## Phases I should NOT cross without operator approval

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,79 @@
 # Changelog
 
+## 0.7.0 — UNRELEASED — Attachments / HFS / webhooks now browser-isomorphic; portable `sync-state.json`
+
+Closes the v0.6.0 webapp coverage gap. The three remaining Node-only resource fetchers (`attachments`, `hf-data`, `webhooks-export`) are refactored to the same `fetch` + `StorageWriter` shape as the v0.6.0 four. The sample browser webapp now offers attachments / HFS / webhooks toggles + a downloadable `sync-state.json` for true cross-session incremental backups.
+
+### Architecture: per-category work refs in the `StateStore`
+
+The `StateStore` interface gains a small ref-tracker on top of the existing kv state:
+
+- `pushRef(category, ref)` — idempotent on `ref.key`; refs carry arbitrary opaque payloads (`{ eventId, attId, fileName, readToken }` for `attachment`, `{ eventId, type }` for `series-event`, `{ accessId, token, type }` for `webhook`)
+- `listPending(category)`, `markDone(category, refKey)`, `clearCategory(category)`
+- `export()` returns a portable JSON snapshot of the kv state (refs deliberately excluded — they are per-run working data)
+- `import(data)` replaces the kv state from a prior `export()` snapshot
+
+Refs flow:
+
+1. **Discover** — `api-resources.toJSONFile` gains an opt-in `onParsed(doc)` tee: when supplied, response bytes are accumulated alongside writing and JSON-decoded at end-of-stream. `events-chunked.download` lifts that into `onEvents(events[])`. The orchestrator wires both hooks to push `attachment` + `series-event` refs (from events) and `webhook` refs (from accesses) into the store as each window streams by.
+2. **Drain** — `attachments.download(connection, writer, stateStore, options, cb, log)`, `hf-data.download(...)`, `webhooks-export.download(...)` all read pending refs from `stateStore.listPending(<category>)`, fetch + write each through the StorageWriter, and call `markDone(<category>, ref.key)` per success. An interrupted run resumes on still-pending refs rather than re-downloading completed work.
+
+### Portable `sync-state.json`
+
+At run-end the orchestrator writes a portable `sync-state.json` via the writer:
+
+```json
+{
+  "format": "pryv-account-backup-sync-state",
+  "formatVersion": 1,
+  "toolVersion": "0.7.0",
+  "createdAt": "<ISO-8601>",
+  "kv": {
+    "lastRunAt": <UTC-sec>,
+    "events.lastModifiedSince": <UTC-sec>,
+    "audit.lastModifiedSince": <UTC-sec>,
+    "formatVersion": 1,
+    "toolVersion": "0.7.0"
+  }
+}
+```
+
+- **CLI:** the file lands in the backup directory alongside the chunked events / accesses / webhooks output. The companion `.sync-state.json` (hidden) keeps the operational store (kv + refs) for the next run; the unhidden `sync-state.json` is the portable artefact.
+- **Browser webapp:** the file is included inside the final ZIP. The subject keeps it alongside the ZIPs and re-uploads it at the start of the next visit; the webapp's pre-login state panel offers the upload, and seeds the store via `import()` so subsequent incremental thresholds carry over even when localStorage is cleared / a different browser is used.
+
+### Added
+
+- **`StateStore` ref tracker + portable export/import** — interface methods documented above; implemented in `FolderStateStore` (Node) with eager file flush. The webapp's `LocalStorageStateStore` mirrors the same interface verbatim.
+- **`attachments.download` browser-isomorphic** — `fetch(<endpoint>/events/<eid>/<attId>?readToken=<rt>)` + `writer.openWriteStream('attachments/<eventId>_<fileName>')`, piped chunk-by-chunk so multi-GB attachments stream through bounded memory in both flavors. Drains refs from `stateStore.listPending('attachment')`; per-download `markDone` enables mid-run resume.
+- **`hf-data.download` browser-isomorphic** — `fetch(<endpoint>/events/<eid>/series)` + `writer.openWriteStream('hf-data/<eid>.json')`. Empty-series 4xx responses are silently marked done so the ref doesn't re-queue indefinitely.
+- **`webhooks-export.download` browser-isomorphic** — `fetch(<endpoint>/webhooks)` per access from `stateStore.listPending('webhook')`, aggregated into `webhooks.json`. 401 / 403 on expired tokens is non-fatal.
+- **`api-resources.onParsed` tee** — opt-in callback that accumulates response bytes alongside writing and JSON-decodes at end of stream. Memory cost O(body size) — acceptable for chunked-events (≤100 MB / file) and accesses payloads; do not enable for legacy multi-GB single-file fetches.
+- **`events-chunked.onEvents` lift** — passes `onParsed` through to `api-resources` and re-emits the parsed `events` array.
+- **Migration from pre-v0.7.0 `.state.json`** — `FolderStateStore` auto-loads kv values from the legacy flat-object file on first construction. Next write lands in `.sync-state.json`; the legacy file is left untouched.
+- **Adapter ref-tracking tests, isomorphism contract tests for the three new modules, and `api-resources.onParsed` / `events-chunked.onEvents` tests** — 16 new unit tests; total suite now 81 passing.
+
+### Removed
+
+- **`JSONStream` dependency** — `attachments.js` was its only consumer; the refactor walks events from in-memory arrays passed by the orchestrator, so the streaming JSON parser is no longer needed. Closes 3 transitive packages.
+
+### Changed
+
+- **Attachment file layout simplified** — output is always `attachments/<eventId>_<fileName>` (flat). The opt-in stream-path-mirrored layout (`attachments/<streamPath>/<eventId>_<fileName>` via `BackupDirectory.settingAttachmentUseStreamsPath`) is dropped — the previous implementation referenced an undeclared helper and would throw on the first attachment whose `streamId` matched a top-level stream. Stream-path metadata is recoverable from `events*.json` + `streams.json` if a consumer needs the old layout.
+- **`Backup.run` now requires a `StateStore`** — pre-v0.7.0 the orchestrator tolerated `state: null` and still ran (in non-incremental mode). v0.7.0 raises a clear error: pass `new FolderStateStore(backupDirectory.baseDir)`. The store is also where per-run refs live, so the orchestration can't drain without it.
+- **`accesses-history.download` signature unchanged** (still takes the in-memory accesses array passed by the orchestrator) — this module's payload sequencing was already incompatible with the per-category ref pattern (one fetch per ref produces independent files; queue semantics add no value).
+- **CLI behavior unchanged from the operator's perspective.** `scripts/start-backup.js` still prompts the same questions; the orchestration delegates to the new `Backup` class internally.
+
+### Compatibility
+
+- A 0.6.0 backup directory's `.state.json` is auto-migrated to `.sync-state.json` on the next 0.7.0 run; kv values are preserved.
+- The `sync-state.json` schema version is `1`. Future versions will bump `formatVersion` and the `StateStore.import(data)` method will reject unsupported versions with a clear error message.
+- 0.6.0 `events-YYYY-MM.json`, `audit_logs.json`, `accesses.json`, `accesses-all.json`, `accesses-history/<id>.json` content shapes are byte-identical in 0.7.0.
+- The CLI's `require('@pryv/account-backup').start(params, callback)` API is preserved verbatim.
+
+### Operator security note (unchanged)
+
+The backup bundle still includes `profile_private.json` with `profile.mfa = { content, recoveryCodes }`. Treat the disclosure as a password-reset-equivalent secret; transport securely; consider rotating recovery codes after the run completes.
+
 ## 0.6.0 — UNRELEASED — Library + CLI split, incremental backup, audit-as-events, browser-isomorphic core
 
 Architectural rewrite around a programmatic library API (`require('@pryv/account-backup').Backup`) consuming pluggable adapters (`StorageWriter` + `StateStore`). The core resource-fetch modules are browser-isomorphic — `fetch` for HTTP, `StorageWriter.openWriteStream` for output. The CLI is preserved as a thin shim; behavior is byte-identical to 0.5.0 on a first run against a fresh backup directory. A sibling `pryv-account-backup-webapp` repository ships the browser-side adapter pair + sample UI.

--- a/README.md
+++ b/README.md
@@ -39,10 +39,12 @@ This downloads the following in JSON format:
 * **Webhooks** per access (`webhooks.json`, keyed by `accessId`) — added in 0.3.0
 
 As well as the following in binary files:
-* Attachment files (when `includeAttachments: true`)
+* Attachment files (when `includeAttachments: true`) — written to `attachments/<eventId>_<fileName>` (flat layout since 0.7.0)
 * **High-frequency series data points** (`hf-data/<eventId>.json`, one per `series:*` event) — added in 0.3.0
 
 Finally, a **per-file integrity manifest** is written to `manifest.json` — sha256 of every other file in the backup, plus tool version + ISO generation timestamp. A third party reading the backup tarball can re-hash each file and compare to detect truncation, corruption, or tampering mid-flight. The `manifest.verify(rootDir, cb)` helper does this programmatically.
+
+A **portable `sync-state.json`** is also written at the root of the backup directory — kv state (incremental thresholds + tool version) only, suitable for moving the disclosure across machines or driving the next run from a different baseDir. The CLI auto-reads it on the next run; the sample webapp accepts it as an upload on its login screen. Schema: [`docs/sync-state.md`](docs/sync-state.md).
 
 ### Running conditions
 
@@ -57,7 +59,7 @@ The package is git-clone-distributed — **not on the npm registry**. Pin to a t
 ```json
 {
   "dependencies": {
-    "pryv-account-backup": "github:pryv/pryv-account-backup#v0.6.0"
+    "pryv-account-backup": "github:pryv/pryv-account-backup#v0.7.0"
   }
 }
 ```
@@ -110,7 +112,9 @@ The class form decouples **what the backup does** (orchestration) from **where t
 
 ### Incremental backup
 
-On the second and subsequent runs against the same backup directory, the orchestrator reads `.state.json` (written at the end of every successful run), fetches events + audit-log entries via `events.get?modifiedSince=T&includeDeletions=true`, and writes a single `events-incremental-<TS>.json` (rather than re-chunking the full history). Small resources (`account`, `streams`, `accesses`, `profile`, `webhooks`) are still full-re-fetched — they're tiny.
+On the second and subsequent runs against the same backup directory, the orchestrator reads `.sync-state.json` (the hidden operational store, written at the end of every successful run; auto-migrated from a pre-v0.7.0 `.state.json` if present), fetches events + audit-log entries via `events.get?modifiedSince=T&includeDeletions=true`, and writes a single `events-incremental-<TS>.json` (rather than re-chunking the full history). Small resources (`account`, `streams`, `accesses`, `profile`, `webhooks`) are still full-re-fetched — they're tiny.
+
+For cross-session / cross-machine portability, the visible companion `sync-state.json` (no leading dot) is also written at the end of each run via the `StorageWriter`. The sample webapp uses this same file as a downloadable + re-uploadable artefact to drive true cross-browser incremental. Full schema at [`docs/sync-state.md`](docs/sync-state.md).
 
 ### Audit log via the standard events API
 

--- a/docs/sync-state.md
+++ b/docs/sync-state.md
@@ -1,0 +1,122 @@
+# `sync-state.json` — portable incremental-backup state
+
+The portable companion file produced at the end of every successful
+backup run since v0.7.0. Both flavors include it in the run output:
+
+- **CLI** — written to `<backupDir>/sync-state.json` (visible, alongside
+  the chunked events / accesses / webhooks output).
+- **Webapp** — embedded inside the final downloadable ZIP at the bundle root.
+
+The file's job is **cross-session incremental**: the subject keeps it
+alongside the backup; on the next run they re-supply it (CLI auto-reads
+the backup directory; the webapp offers an upload picker on the login
+screen). The library hydrates the `StateStore` from it, and the next run
+issues `events?modifiedSince=…` / `audit-as-events?modifiedSince=…`
+instead of a full chunked refetch.
+
+## Schema (formatVersion 1)
+
+```json
+{
+  "format": "pryv-account-backup-sync-state",
+  "formatVersion": 1,
+  "toolVersion": "0.7.0",
+  "createdAt": "2026-06-15T16:43:27.000Z",
+  "kv": {
+    "lastRunAt": 1781542207,
+    "events.lastModifiedSince": 1781542207,
+    "audit.lastModifiedSince": 1781542207,
+    "formatVersion": 1,
+    "toolVersion": "0.7.0"
+  }
+}
+```
+
+| Field | Type | Notes |
+|---|---|---|
+| `format` | string (literal) | Always `"pryv-account-backup-sync-state"`. Used by `StateStore.import()` to refuse unrelated JSON files. |
+| `formatVersion` | integer | Schema version; current value is `1`. `import()` rejects unsupported versions with a clear error message. |
+| `toolVersion` | string (semver) | Version of `@pryv/account-backup` that produced the file. Diagnostic only — not enforced on import. |
+| `createdAt` | string (ISO-8601 UTC) | Wall-clock at export-time. Diagnostic only. |
+| `kv.lastRunAt` | integer (UTC seconds) | Start timestamp of the run that produced this file. Read on the next run to gate "is there prior state?". |
+| `kv.events.lastModifiedSince` | integer (UTC seconds) | The threshold for the next `events.get?modifiedSince=…` round-trip. Conservatively set to `lastRunAt` (events modified strictly *after* this point flow over the wire next time; events modified *during* the run get a small overlap on the next run, which is harmless — duplicates write identically and re-imports are idempotent at the event-id key). |
+| `kv.audit.lastModifiedSince` | integer (UTC seconds) | Same semantics as the events threshold, applied to the `:_audit:*` streams fetch. |
+| `kv.formatVersion` / `kv.toolVersion` | int / string | Mirror of the envelope fields; recorded inside `kv` so they survive an export/import round-trip and tools that inspect only the kv tree still see them. |
+
+## What is NOT in the export
+
+- **Refs.** Per-category work refs (`attachment`, `series-event`, `webhook`)
+  discovered during a run are kept in the operational store but **dropped
+  from the portable export**. Each run re-discovers refs from the events
+  + accesses streams; persisting completed refs across runs adds no value,
+  and persisting pending refs across runs invites stale-token / phantom
+  bugs (a webhook ref whose access has since been revoked is better
+  re-discovered than re-tried).
+
+- **Tokens / credentials.** The file carries no auth material. The
+  subject must re-authenticate on every run (CLI prompt; webapp login
+  form).
+
+- **Resource content.** This file is metadata about the backup; the
+  backup data itself lives in the sibling JSON / binary / ZIP files.
+
+## Lifecycle
+
+```
+run N:
+  start
+    └── state.export()                        ⤴
+                                              │
+    fetch + drain (refs in operational store) │
+                                              │
+  end                                         │
+    └── writer.openWriteStream('sync-state.json').write(JSON.stringify(snapshot))
+                                              │
+                  ┌───────────────────────────┘
+                  ▼
+              keep alongside ZIPs / on disk
+
+run N+1:
+  CLI:    FolderStateStore auto-reads <baseDir>/.sync-state.json
+          (or migrates from pre-v0.7.0 <baseDir>/.state.json)
+  Webapp: subject uploads sync-state.json on the login screen
+          → LocalStorageStateStore.import(file)
+  Then: orchestrator reads kv.lastRunAt + thresholds → incremental fetch
+```
+
+## CLI: hidden operational vs. visible portable
+
+The CLI ships **two** sync-state files in the backup directory:
+
+- `.sync-state.json` (hidden; the operational store) — kv state +
+  per-category refs. Refs accumulate during a run and are pruned at
+  export-time. Survives interrupted runs so a re-run can resume.
+- `sync-state.json` (visible; the portable artefact) — kv state only,
+  written via the `StorageWriter` at the end of the run. The subject's
+  copy if they want to move the disclosure across machines / re-run
+  from a different baseDir.
+
+Both files share the same `formatVersion` and are mutually consistent
+after a clean run.
+
+## Webapp: localStorage operational + ZIP-shipped portable
+
+- **Operational store:** `localStorage["pryv-account-backup:state:<apiEndpoint>"]`
+  carries the same `{ kv, refs }` shape (same schema; refs survive
+  tab-close).
+- **Portable export:** `sync-state.json` embedded inside the final ZIP.
+  When the subject re-uploads it on the next visit, the pre-login UI
+  imports the kv state and the next run goes incremental.
+
+## Versioning policy
+
+- Backward-compatible changes (new optional `kv` keys, new envelope
+  metadata fields) keep `formatVersion: 1`.
+- Schema breaks (renaming a `kv` key, changing field semantics) bump
+  `formatVersion`. `StateStore.import(data)` will reject unsupported
+  versions with `StateStore.import: unsupported formatVersion X
+  (expected Y)`.
+- The `format` literal is reserved and will not change between versions
+  — it stays `"pryv-account-backup-sync-state"` so unrelated JSON files
+  (operator-side backup snapshots, third-party tools) are rejected
+  cleanly.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "async": "^3.2.6",
-        "JSONStream": "^1.3.5",
         "pryv": "^3.4.1",
         "read": "^5.0.1"
       },
@@ -1357,31 +1356,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha512-POQXvpdL69+CluYsillJ7SUhKvytYjW9vG/GKpnf+xP8UWgYEM/RaMzHHofbALDiKbbP1W8UEYmgGl39WkPZsg==",
-      "engines": [
-        "node >= 0.2.0"
-      ],
-      "license": "MIT"
-    },
-    "node_modules/JSONStream": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.5.tgz",
-      "integrity": "sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==",
-      "license": "(MIT OR Apache-2.0)",
-      "dependencies": {
-        "jsonparse": "^1.2.0",
-        "through": ">=2.2.7 <3"
-      },
-      "bin": {
-        "JSONStream": "bin.js"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -2059,12 +2033,6 @@
       "funding": {
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
-    },
-    "node_modules/through": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
-      "license": "MIT"
     },
     "node_modules/which": {
       "version": "2.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pryv/account-backup",
   "description": "Backup your Pryv account",
-  "version": "0.5.0",
+  "version": "0.7.0",
   "private": false,
   "keywords": [
     "Pryv",
@@ -34,7 +34,6 @@
   ],
   "dependencies": {
     "async": "^3.2.6",
-    "JSONStream": "^1.3.5",
     "pryv": "^3.4.1",
     "read": "^5.0.1"
   },

--- a/src/lib/Backup.js
+++ b/src/lib/Backup.js
@@ -19,15 +19,28 @@ const STATE_KEYS = {
   auditLastModifiedSince: 'audit.lastModifiedSince'
 };
 
+const SYNC_STATE_FILE = 'sync-state.json';
+
 /**
  * Backup — the orchestrator that runs a full account dump.
  *
- * Phase A: this class wraps the v0.5.0 `startOnConnection` orchestration so
- * the library has a class entrypoint that consumes pluggable adapters
- * (`StorageWriter` + `StateStore`). Behavior is identical to v0.5.0 — the
- * per-method modules still consume the legacy `BackupDirectory` exposed via
- * the writer's `legacyDirectory()` shim. Phase B will migrate the per-method
- * modules to consume the writer + state directly.
+ * Drives two pluggable adapters: `StorageWriter` (bytes out) +
+ * `StateStore` (kv state + per-category work refs). The same orchestration
+ * runs in both Node and the browser sample webapp.
+ *
+ * Per-resource refs (attachments, series-event, webhook) are PUSHED into the
+ * StateStore during metadata + events fetches via the `onParsed` hook in
+ * `api-resources` (and the `onEvents` lift in `events-chunked`), then DRAINED
+ * by the per-method modules (`attachments.download`, `hf-data.download`,
+ * `webhooks-export.download`). Each successful per-ref download is marked
+ * done in the store so an interrupted run resumes on still-pending refs
+ * rather than re-downloading completed work.
+ *
+ * At run-end the orchestrator writes a portable `sync-state.json` via the
+ * writer — kv state only, no refs. CLI subjects find it in the backup
+ * directory; webapp subjects find it inside the final ZIP. They keep it
+ * alongside their backup; on the next run they re-upload it (webapp) or
+ * the CLI auto-reads it from disk, and incremental thresholds carry over.
  *
  * Typical CLI usage:
  *
@@ -36,20 +49,18 @@ const STATE_KEYS = {
  *   const state = new FolderStateStore(backupDirectory.baseDir);
  *   const backup = new Backup({ connection, writer, state, options });
  *   backup.run((err) => { ... });
- *
- * The CLI's `scripts/start-backup.js` continues to call the legacy
- * `exports.start(params, callback)` API in `src/main.js`, which constructs a
- * `Backup` internally; existing CLI users see no behavior change.
  */
 class Backup {
   /**
    * @param {object} cfg
    * @param {object} cfg.connection         pryv.Connection (logged-in)
    * @param {StorageWriter} cfg.writer      destination adapter
-   * @param {StateStore} [cfg.state]        incremental state (Phase B uses this)
+   * @param {StateStore} [cfg.state]        kv state + work-ref tracker
    * @param {object} [cfg.options]          per-run options
    * @param {boolean} [cfg.options.includeTrashed]
    * @param {boolean} [cfg.options.includeAttachments]
+   * @param {boolean} [cfg.options.includeHfData]
+   * @param {boolean} [cfg.options.includeWebhooks]
    * @param {boolean} [cfg.options.includeAccessHistory]
    * @param {number}  [cfg.options.eventsChunkMonths]
    * @param {number}  [cfg.options.fromTime]
@@ -68,21 +79,24 @@ class Backup {
   }
 
   /**
-   * Run the backup. Mirrors the v0.5.0 `startOnConnection` flow:
+   * Run the backup. Flow:
    *   1. metadata resources (account, streams, accesses + accesses-all,
-   *      profile/private, profile/public, audit/logs)
-   *   2. per-app profile fetches (`/profile/app` per `app`-type access)
-   *   3. events chunked by month (`events-YYYY-MM.json`)
-   *   4. per-access version history (`accesses-history/<id>.json`, opt-in)
-   *   5. attachments (opt-in)
-   *   6. HFS series data points (per `series:*` event)
-   *   7. webhooks per access
-   *   8. integrity manifest
+   *      profile/private, profile/public) — accesses fetch tees webhook refs
+   *      into the store
+   *   2. audit-as-events
+   *   3. events chunked by month (or incremental) — tees attachment +
+   *      series-event refs into the store
+   *   4. per-app profile fetches
+   *   5. per-access version history (opt-in)
+   *   6. attachments drain (opt-in)
+   *   7. HFS series data points drain (opt-in)
+   *   8. webhooks drain (opt-in)
+   *   9. persist sync-state kv + write portable `sync-state.json` via writer
+   *  10. integrity manifest
    *
    * @param {function(Error?)} callback
    */
   run (callback) {
-    const self = this;
     const connection = this.connection;
     const writer = this.writer;
     const state = this.state;
@@ -95,40 +109,94 @@ class Backup {
         'Pass `new NodeFsStorageWriter(backupDirectory)` rather than a bare path.'
       ));
     }
+    if (state == null) {
+      return callback(new Error('Backup requires a StateStore (since v0.7.0). ' +
+        'Pass `new FolderStateStore(backupDirectory.baseDir)`.'));
+    }
 
     const runStartedAt = Math.floor(Date.now() / 1000);
 
-    // Resolve incremental thresholds from prior state. When the state store
-    // is absent OR carries no prior `lastRunAt`, this is the first run on
-    // this backup directory — fall back to the chunked initial-fetch path.
     let eventsModifiedSince = null;
     let auditModifiedSince = null;
     (async function loadIncrementalState () {
-      if (state == null) return;
       const prior = await state.get(STATE_KEYS.lastRunAt);
       if (prior == null) return;
       eventsModifiedSince = await state.get(STATE_KEYS.eventsLastModifiedSince);
       auditModifiedSince = await state.get(STATE_KEYS.auditLastModifiedSince);
-      // Fall back to lastRunAt if a resource-level threshold is missing.
       if (eventsModifiedSince == null) eventsModifiedSince = prior;
       if (auditModifiedSince == null) auditModifiedSince = prior;
     })().then(runOrchestration, callback);
+
+    function pushAttachmentRefs (events) {
+      return Promise.all(events.map(async function (e) {
+        if (!e || !Array.isArray(e.attachments)) return;
+        for (const att of e.attachments) {
+          if (!att || !att.id) continue;
+          await state.pushRef('attachment', {
+            key: e.id + ':' + att.id,
+            eventId: e.id,
+            attId: att.id,
+            fileName: att.fileName || att.id,
+            readToken: att.readToken
+          });
+        }
+      })).then(function () {});
+    }
+
+    function pushSeriesEventRefs (events) {
+      return Promise.all(events.map(async function (e) {
+        if (!e || typeof e.type !== 'string' || e.type.indexOf('series:') !== 0) return;
+        await state.pushRef('series-event', {
+          key: e.id,
+          eventId: e.id,
+          type: e.type
+        });
+      })).then(function () {});
+    }
+
+    function onEventsParsed (events) {
+      return Promise.all([
+        pushAttachmentRefs(events),
+        pushSeriesEventRefs(events)
+      ]).then(function () {});
+    }
+
+    function onAccessesParsed (doc) {
+      const accesses = Array.isArray(doc.accesses) ? doc.accesses : [];
+      return Promise.all(accesses.map(async function (a) {
+        if (!a || typeof a.token !== 'string' || a.token.length === 0) return;
+        await state.pushRef('webhook', {
+          key: a.id,
+          accessId: a.id,
+          token: a.token,
+          type: a.type
+        });
+      })).then(function () {});
+    }
 
     function runOrchestration () {
       async.series([
         function createDirectoryTree (done) {
           backupDirectory.createDirs(done, log);
         },
+        function clearStaleRefs (done) {
+          // Carry-over refs from a prior interrupted run get re-discovered
+          // via the events / accesses streams below; clearing the store
+          // sidesteps "phantom pending" refs whose threshold has since moved.
+          Promise.all([
+            state.clearCategory('attachment'),
+            state.clearCategory('series-event'),
+            state.clearCategory('webhook')
+          ]).then(function () { done(); }, done);
+        },
         function fetchData (done) {
           log('Starting Backup' + (eventsModifiedSince != null ? ' (incremental)' : ' (initial)'));
 
-          // Skip metadata fetch on incremental re-runs — the small resources
-          // get full-refetched below. The skip-on-events-present check is
-          // preserved for backwards compatibility with v0.5.0 partial-rerun
-          // behavior (operator interrupted the first run, restarts with
-          // events already on disk).
           if (eventsModifiedSince == null && backupDirectory.hasEventsData()) {
-            return done();
+            // Operator interrupted an earlier run; events on disk are
+            // preserved. Re-derive accesses-keyed webhook refs from disk so
+            // the drain step still has work to do.
+            return reloadAccessesFromDisk(backupDirectory, onAccessesParsed, log, done);
           }
 
           let streamsRequest = 'streams';
@@ -136,21 +204,22 @@ class Backup {
             streamsRequest += '?state=all';
           }
 
-          // Audit no longer rides this list — it's fetched via
-          // events.get on :_audit:* streams in a dedicated step below so
-          // modifiedSince applies (the dedicated /audit/logs endpoint does
-          // not support modifiedSince and is being removed from the API).
           const accessesAllRequest = 'accesses?includeDeletions=true&includeExpired=true';
-          async.mapSeries([
-            'account', streamsRequest, 'accesses', accessesAllRequest,
-            'profile/private', 'profile/public'
-          ], function (resource, cb) {
-            const extra = resource === accessesAllRequest ? '-all' : '';
+          const resources = [
+            { res: 'account' },
+            { res: streamsRequest },
+            { res: 'accesses', onParsed: onAccessesParsed },
+            { res: accessesAllRequest, extra: '-all' },
+            { res: 'profile/private' },
+            { res: 'profile/public' }
+          ];
+          async.mapSeries(resources, function (item, cb) {
             apiResources.toJSONFile({
               writer: writer,
-              resource: resource,
-              extraFileName: extra,
-              connection: connection
+              resource: item.res,
+              extraFileName: item.extra || '',
+              connection: connection,
+              onParsed: item.onParsed
             }, cb, log);
           }, done);
         },
@@ -167,13 +236,11 @@ class Backup {
             runStartedAt: runStartedAt,
             fromTime: params.fromTime,
             toTime: params.toTime,
-            chunkMonths: params.eventsChunkMonths
+            chunkMonths: params.eventsChunkMonths,
+            onEvents: onEventsParsed
           }, stepDone, log);
         },
         function fetchAppProfiles (stepDone) {
-          // The per-app-profile fetches go into the `app_profiles/`
-          // subdirectory; api-resources writes via the writer, which routes
-          // the relative path under baseDir.
           const accessesData = JSON.parse(fs.readFileSync(backupDirectory.accessesFile, 'utf8'));
           async.mapSeries(accessesData.accesses, function (access, cb) {
             if (access.type !== 'app') return cb();
@@ -191,40 +258,51 @@ class Backup {
             log('Skipping per-access version history (opt-in)');
             return stepDone();
           }
-          // Pass the accesses array explicitly so accesses-history doesn't
-          // need to read disk — keeps the per-method module browser-friendly.
           const accessesData = JSON.parse(fs.readFileSync(backupDirectory.accessesFile, 'utf8'));
           accessesHistory.download(connection, writer, accessesData.accesses || [], stepDone, log);
         },
-        function fetchAttachments (stepDone) {
-          if (params.includeAttachments) {
-            attachments.download(connection, backupDirectory, stepDone, log);
-          } else {
+        function drainAttachments (stepDone) {
+          if (!params.includeAttachments) {
             log('Skipping attachments');
-            stepDone();
+            return stepDone();
           }
+          attachments.download(connection, writer, state, {}, stepDone, log);
         },
-        function fetchHFData (stepDone) {
-          hfData.download(connection, backupDirectory, stepDone, log);
+        function drainHfData (stepDone) {
+          if (params.includeHfData === false) {
+            log('Skipping HFS series data (opt-out)');
+            return stepDone();
+          }
+          hfData.download(connection, writer, state, {}, stepDone, log);
         },
-        function fetchWebhooks (stepDone) {
-          webhooksExport.download(connection, backupDirectory, stepDone, log);
+        function drainWebhooks (stepDone) {
+          if (params.includeWebhooks === false) {
+            log('Skipping webhooks (opt-out)');
+            return stepDone();
+          }
+          webhooksExport.download(connection, writer, state, {}, stepDone, log);
         },
         function persistRunState (stepDone) {
-          if (state == null) return stepDone();
-          // Persist incremental thresholds for the next run. Use the
-          // run-start timestamp as the threshold — events / audit modified
-          // strictly after `runStartedAt` will be picked up next time.
-          // Conservative: re-fetch any event modified DURING the run (a small
-          // overlap is harmless; missing one is not).
-          (async () => {
+          (async function () {
             await state.set(STATE_KEYS.formatVersion, STATE_FORMAT_VERSION);
             await state.set(STATE_KEYS.toolVersion, pkg.version);
             await state.set(STATE_KEYS.lastRunAt, runStartedAt);
             await state.set(STATE_KEYS.eventsLastModifiedSince, runStartedAt);
             await state.set(STATE_KEYS.auditLastModifiedSince, runStartedAt);
             await state.flush();
-          })().then(() => stepDone(), stepDone);
+          })().then(function () { stepDone(); }, stepDone);
+        },
+        function writeSyncStateFile (stepDone) {
+          (async function () {
+            const snapshot = await state.export();
+            const body = JSON.stringify(snapshot, null, 2);
+            const ws = writer.openWriteStream(SYNC_STATE_FILE);
+            ws.write(body);
+            await new Promise(function (resolve, reject) {
+              if (typeof ws.end !== 'function') return resolve();
+              ws.end(function (err) { err ? reject(err) : resolve(); });
+            });
+          })().then(function () { stepDone(); }, stepDone);
         },
         function writeManifest (stepDone) {
           manifest.generate(backupDirectory.baseDir, { version: pkg.version, log }, stepDone);
@@ -242,5 +320,20 @@ class Backup {
 
 Backup.STATE_FORMAT_VERSION = STATE_FORMAT_VERSION;
 Backup.STATE_KEYS = STATE_KEYS;
+Backup.SYNC_STATE_FILE = SYNC_STATE_FILE;
 
 module.exports = Backup;
+
+function reloadAccessesFromDisk (backupDirectory, onParsed, log, callback) {
+  if (!fs.existsSync(backupDirectory.accessesFile)) {
+    log('No accesses.json on disk — skipping webhook-ref reload.');
+    return callback();
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(fs.readFileSync(backupDirectory.accessesFile, 'utf8'));
+  } catch (err) {
+    return callback(err);
+  }
+  Promise.resolve(onParsed(parsed)).then(function () { callback(); }, callback);
+}

--- a/src/lib/adapters/FolderStateStore.js
+++ b/src/lib/adapters/FolderStateStore.js
@@ -3,17 +3,26 @@ const path = require('path');
 const StateStore = require('./StateStore');
 
 /**
- * Folder-backed StateStore — persists state to a `.state.json` sentinel file
- * inside the backup directory. Used by the CLI flavor.
+ * Folder-backed StateStore — persists state to `<baseDir>/.sync-state.json`
+ * (hidden). Used by the CLI flavor.
  *
- * The state file holds incremental-run metadata: `lastRunAt`,
- * `lastModifiedSince` per resource, tool version, format version. It is read
- * at startup and rewritten on each `set` / `flush` call. The file is at the
- * root of the backup directory (alongside `account.json`, `manifest.json`,
- * etc.) and is included in the integrity manifest like any other file.
+ * The file holds the union of kv state (incremental thresholds + tool
+ * metadata) and per-category work refs (attachment / series-event / webhook
+ * discovered during a run + their done-state). It is loaded at startup and
+ * rewritten on each `flush()` (set/markDone/clearCategory call `flush`
+ * eagerly, so no caller-side `flush()` is strictly required).
  *
- * Phase A: the orchestrator does not yet consume state; this class is wired
- * for Phase B which writes the incremental timestamps.
+ * Migration: if `.sync-state.json` is absent but the legacy `.state.json`
+ * (pre-v0.7.0) is present, its kv state is loaded as-is; the next write
+ * lands in `.sync-state.json` and the legacy file is left in place (Node
+ * fs is forgiving; the legacy reader becomes inert without orchestrator
+ * support).
+ *
+ * Companion export: `Backup.run()` writes a kv-only `sync-state.json`
+ * (no dot, visible) into the backup directory at run-end via the writer —
+ * that's the file a subject keeps and re-uploads on the next run. The
+ * hidden `.sync-state.json` carries refs and is the operational store;
+ * the exported `sync-state.json` is the portable artefact.
  */
 class FolderStateStore extends StateStore {
   /**
@@ -22,36 +31,110 @@ class FolderStateStore extends StateStore {
   constructor (baseDir) {
     super();
     this.baseDir = baseDir;
-    this.stateFile = path.resolve(baseDir, '.state.json');
+    this.stateFile = path.resolve(baseDir, '.sync-state.json');
+    this._legacyStateFile = path.resolve(baseDir, '.state.json');
     this._state = this._load();
   }
 
   _load () {
-    if (!fs.existsSync(this.stateFile)) return {};
-    try {
-      return JSON.parse(fs.readFileSync(this.stateFile, 'utf8'));
-    } catch (err) {
-      // Corrupted state file — start fresh rather than aborting the backup.
-      return {};
+    const empty = { kv: {}, refs: {} };
+    let raw = null;
+    if (fs.existsSync(this.stateFile)) {
+      try { raw = fs.readFileSync(this.stateFile, 'utf8'); } catch (_) { return empty; }
+    } else if (fs.existsSync(this._legacyStateFile)) {
+      // Pre-v0.7.0 layout — flat kv object at the file root.
+      try {
+        const flat = JSON.parse(fs.readFileSync(this._legacyStateFile, 'utf8'));
+        return { kv: flat && typeof flat === 'object' ? flat : {}, refs: {} };
+      } catch (_) { return empty; }
+    } else {
+      return empty;
     }
+    let parsed;
+    try { parsed = JSON.parse(raw); } catch (_) { return empty; }
+    if (parsed == null || typeof parsed !== 'object') return empty;
+    return {
+      kv: parsed.kv && typeof parsed.kv === 'object' ? parsed.kv : {},
+      refs: parsed.refs && typeof parsed.refs === 'object' ? parsed.refs : {}
+    };
   }
 
+  // ─── Key/value state ───
+
   async get (key) {
-    return this._state[key];
+    return this._state.kv[key];
   }
 
   async set (key, value) {
-    this._state[key] = value;
+    this._state.kv[key] = value;
     await this.flush();
   }
 
   async getAll () {
-    return { ...this._state };
+    return { ...this._state.kv };
   }
 
   async flush () {
     fs.mkdirSync(path.dirname(this.stateFile), { recursive: true });
     fs.writeFileSync(this.stateFile, JSON.stringify(this._state, null, 2));
+  }
+
+  // ─── Per-category ref tracking ───
+
+  async pushRef (category, ref) {
+    if (ref == null || typeof ref.key !== 'string') {
+      throw new Error('StateStore.pushRef requires ref.key (string)');
+    }
+    const list = this._state.refs[category] || (this._state.refs[category] = []);
+    if (list.some((r) => r.key === ref.key)) return; // idempotent
+    list.push({ ...ref, done: false });
+    await this.flush();
+  }
+
+  async listPending (category) {
+    const list = this._state.refs[category] || [];
+    return list.filter((r) => !r.done).map((r) => ({ ...r }));
+  }
+
+  async markDone (category, refKey) {
+    const list = this._state.refs[category] || [];
+    const found = list.find((r) => r.key === refKey);
+    if (found) {
+      found.done = true;
+      await this.flush();
+    }
+  }
+
+  async clearCategory (category) {
+    if (this._state.refs[category]) {
+      delete this._state.refs[category];
+      await this.flush();
+    }
+  }
+
+  // ─── Portable export / import ───
+
+  async export () {
+    return {
+      format: StateStore.FORMAT,
+      formatVersion: StateStore.FORMAT_VERSION,
+      toolVersion: this._state.kv.toolVersion || null,
+      createdAt: new Date().toISOString(),
+      kv: { ...this._state.kv }
+    };
+  }
+
+  async import (data) {
+    if (data == null || data.format !== StateStore.FORMAT) {
+      throw new Error('StateStore.import: unrecognized format (expected ' +
+        StateStore.FORMAT + ')');
+    }
+    if (data.formatVersion !== StateStore.FORMAT_VERSION) {
+      throw new Error('StateStore.import: unsupported formatVersion ' +
+        data.formatVersion + ' (expected ' + StateStore.FORMAT_VERSION + ')');
+    }
+    this._state.kv = (data.kv && typeof data.kv === 'object') ? { ...data.kv } : {};
+    await this.flush();
   }
 }
 

--- a/src/lib/adapters/StateStore.js
+++ b/src/lib/adapters/StateStore.js
@@ -1,22 +1,40 @@
 /**
- * StateStore — interface for tracking incremental-backup progress.
+ * StateStore — interface for tracking incremental-backup progress + in-run
+ * work refs.
  *
  * The library is consumed in two flavors:
  *   - CLI (Node): persists state to a sentinel file in the backup directory
- *     (FolderStateStore).
+ *     (FolderStateStore — `<baseDir>/.sync-state.json`).
  *   - Browser: persists state to `localStorage` (LocalStorageStateStore, ships
  *     in the sample webapp).
  *
- * The orchestrator stores per-resource `lastModifiedSince` timestamps + run
- * metadata between sessions so a re-run picks up only what's new.
+ * Two concerns live in the store:
  *
- * Phase A: the interface is defined and a `MemoryStateStore` default exists
- * for tests. The CLI ships a `FolderStateStore`. The orchestrator does NOT
- * yet consume the state — Phase B wires it through the resource fetchers.
+ *   1. **Key/value state** (`get` / `set` / `getAll`): cross-session
+ *      incremental thresholds (`lastRunAt`, `events.lastModifiedSince`,
+ *      `audit.lastModifiedSince`, …) and tool metadata.
+ *
+ *   2. **Per-category refs** (`pushRef` / `listPending` / `markDone` / …):
+ *      work-queue entries discovered during a fetch step and consumed by a
+ *      later step — e.g. attachment refs discovered while events stream by,
+ *      drained later by the attachments downloader.
+ *
+ * The store is also responsible for portable export/import:
+ *
+ *   - `export()` returns a JSON-able snapshot of the kv state (refs are
+ *     deliberately dropped — they are per-run working data; the next run
+ *     re-discovers any genuinely missing refs via `modifiedSince`).
+ *   - `import(data)` replaces the kv state from a prior `export()` output —
+ *     the cornerstone of browser-side cross-session incremental, since
+ *     localStorage can be cleared / scoped to a single browser. The subject
+ *     downloads `sync-state.json` at the end of a run and re-uploads it at
+ *     the start of the next run.
  *
  * @abstract
  */
 class StateStore {
+  // ─── Key/value state ───
+
   /**
    * Retrieve a value previously set via `set`.
    * @param {string} key
@@ -52,6 +70,90 @@ class StateStore {
   async flush () {
     throw new Error('StateStore.flush not implemented');
   }
+
+  // ─── Per-category ref tracking ───
+
+  /**
+   * Record a work ref under `category`. Idempotent on `ref.key` within a
+   * category — re-pushing the same key is a no-op (the existing entry's
+   * `done` flag is preserved).
+   *
+   * @param {string} category e.g. 'attachment', 'series-event', 'webhook'
+   * @param {object} ref      must carry a `key` string; rest is opaque payload
+   *                          consumed by the draining step (URL params, tokens, …)
+   * @returns {Promise<void>}
+   */
+  async pushRef (category, ref) {
+    throw new Error('StateStore.pushRef not implemented');
+  }
+
+  /**
+   * List refs in `category` that have not yet been marked done.
+   * @param {string} category
+   * @returns {Promise<Array<object>>}
+   */
+  async listPending (category) {
+    throw new Error('StateStore.listPending not implemented');
+  }
+
+  /**
+   * Mark the ref keyed by `refKey` in `category` as done.
+   * @param {string} category
+   * @param {string} refKey
+   * @returns {Promise<void>}
+   */
+  async markDone (category, refKey) {
+    throw new Error('StateStore.markDone not implemented');
+  }
+
+  /**
+   * Remove every ref in `category`. Called at the start of a fresh run to
+   * discard stale work from a prior interrupted attempt that has been
+   * subsumed by the new incremental threshold.
+   * @param {string} category
+   * @returns {Promise<void>}
+   */
+  async clearCategory (category) {
+    throw new Error('StateStore.clearCategory not implemented');
+  }
+
+  // ─── Portable export / import ───
+
+  /**
+   * Serialize the store to a JSON-able snapshot. Refs are excluded by
+   * design — they are per-run working data. The returned object has the
+   * `sync-state.json` schema:
+   *
+   *   {
+   *     format: 'pryv-account-backup-sync-state',
+   *     formatVersion: 1,
+   *     toolVersion: '<semver>',
+   *     createdAt: '<ISO-8601>',
+   *     kv: { ... }
+   *   }
+   *
+   * @returns {Promise<object>}
+   */
+  async export () {
+    throw new Error('StateStore.export not implemented');
+  }
+
+  /**
+   * Replace the kv state from a prior `export()` snapshot. Refs are NOT
+   * imported. The webapp calls this after the subject uploads a previously
+   * downloaded `sync-state.json`.
+   *
+   * Throws if `data.format` doesn't match or `formatVersion` is unsupported.
+   *
+   * @param {object} data prior export() output
+   * @returns {Promise<void>}
+   */
+  async import (data) {
+    throw new Error('StateStore.import not implemented');
+  }
 }
+
+StateStore.FORMAT = 'pryv-account-backup-sync-state';
+StateStore.FORMAT_VERSION = 1;
 
 module.exports = StateStore;

--- a/src/methods/api-resources.js
+++ b/src/methods/api-resources.js
@@ -9,11 +9,21 @@
  * in `NodeFsStorageWriter` once (in `Backup.run`) and passes the writer to
  * this module — that keeps this file Node-free and browser-bundle-clean.
  *
+ * Optional `params.onParsed` hook (v0.7.0): when supplied, the response bytes
+ * are also accumulated in memory alongside writing, JSON-decoded at end-of-
+ * stream, and `onParsed(parsedDoc)` is fired before the callback. The
+ * orchestrator uses this to extract work refs (attachments, series-events,
+ * webhooks) from event/accesses payloads as they fetch, push them into the
+ * `StateStore`, then drain them in a later step. Memory cost: O(body size) —
+ * acceptable for chunked-events (<100 MB / file) + accesses payloads; do NOT
+ * enable for legacy multi-GB single-file events fetches.
+ *
  * @param params.writer       StorageWriter (required)
  * @param params.resource     Pryv API resource path, e.g. `events?modifiedSince=…`
  * @param params.connection   { endpoint, token }
  * @param params.extraFileName  optional suffix appended before `.json`
  * @param params.filename     optional full output filename (overrides derivation)
+ * @param params.onParsed     optional (parsedJsonDoc) => void; see above
  * @param callback (err)
  * @param log optional log fn
  */
@@ -42,6 +52,9 @@ exports.toJSONFile = function streamApiToFile (params, callback, log) {
   };
   setTimeout(timeLog, 1000);
 
+  const onParsed = typeof params.onParsed === 'function' ? params.onParsed : null;
+  const buffer = onParsed ? [] : null;
+
   (async function () {
     const res = await fetch(fullUrl, {
       headers: { Authorization: connection.token }
@@ -59,10 +72,24 @@ exports.toJSONFile = function streamApiToFile (params, callback, log) {
       if (streamDone) break;
       total += value.byteLength;
       writeStream.write(value);
+      if (buffer) buffer.push(value);
     }
     await endStream(writeStream);
     done = true;
     log('Received: ' + outputFilename + ' ' + prettyPrint(total));
+
+    if (onParsed) {
+      const merged = mergeChunks(buffer);
+      try {
+        const parsed = JSON.parse(new TextDecoder().decode(merged));
+        await onParsed(parsed);
+      } catch (parseErr) {
+        // Ref-collection failure is non-fatal — the file is already on disk;
+        // a later run can re-pick refs via modifiedSince.
+        log('onParsed: skipped (failed to decode ' + outputFilename +
+          ' — ' + (parseErr.message || parseErr) + ')');
+      }
+    }
   })().then(
     function () { callback(); },
     function (err) {
@@ -74,6 +101,15 @@ exports.toJSONFile = function streamApiToFile (params, callback, log) {
     }
   );
 };
+
+function mergeChunks (chunks) {
+  let total = 0;
+  for (const c of chunks) total += c.byteLength;
+  const out = new Uint8Array(total);
+  let off = 0;
+  for (const c of chunks) { out.set(c, off); off += c.byteLength; }
+  return out;
+}
 
 function resolveWriter (params) {
   if (params.writer != null) return params.writer;

--- a/src/methods/attachments.js
+++ b/src/methods/attachments.js
@@ -1,176 +1,120 @@
 const async = require('async');
-const fs = require('fs');
-const path = require('path');
-const https = require('https');
-const JSONStream = require('JSONStream');
+
+const CATEGORY = 'attachment';
 
 /**
- * Parses the events from the provided file and downloads their attachments
+ * Download every binary attachment whose ref is queued under the
+ * `attachment` category in the StateStore.
  *
- * @param connection {pryv.Connection}
- * @param backupDir {backup-directory}
- * @param callback
+ * Browser-isomorphic since v0.7.0:
+ *   - HTTP: global `fetch`,
+ *   - disk: `writer.openWriteStream('attachments/<eid>_<fileName>')`,
+ *   - work queue: `stateStore.listPending('attachment')` populated by the
+ *     orchestrator from the events stream via the `onParsed` hook.
+ *
+ * Per-attachment URL: `<apiEndpoint>events/<eid>/<attId>?readToken=<rt>`.
+ * The response stream is piped chunk-by-chunk into the writer; no full-body
+ * buffering, so multi-GB attachments stream through bounded memory in both
+ * flavors. Each successful download is marked done in the store, so an
+ * interrupted run resumes only the still-pending refs on the next attempt.
+ *
+ * Ref schema (pushed by the orchestrator):
+ *   { key: '<eventId>:<attId>', eventId, attId, fileName, readToken }
+ *
+ * @param connection   { endpoint, token }
+ * @param writer       StorageWriter
+ * @param stateStore   StateStore (drains category 'attachment')
+ * @param options      { concurrency?: number }   default 10 parallel downloads
+ * @param callback     (err)
+ * @param log          (msg)
  */
-exports.download = function (connection, backupDir, callback, log) {
-  if (!log) {
-    log = console.log;
+exports.download = function download (connection, writer, stateStore, options, callback, log) {
+  if (!log) log = console.log;
+  if (writer == null || typeof writer.openWriteStream !== 'function') {
+    throw new Error('attachments.download requires a StorageWriter');
   }
+  if (stateStore == null || typeof stateStore.listPending !== 'function') {
+    throw new Error('attachments.download requires a StateStore');
+  }
+  options = options || {};
+  const concurrency = options.concurrency || 10;
 
-  loadStreamMapIfNeed(backupDir, log);
-  loadEventFile(connection, backupDir, function (error, attachments) {
-    if (error) {
-      log('Failed parsing event file for attachments' + error);
-      return callback(error);
+  (async function () {
+    const refs = await stateStore.listPending(CATEGORY);
+    if (refs.length === 0) {
+      log('attachments: no pending attachments');
+      return [];
     }
-
-    // Download attachment files in 10 parralel calls
-    async.mapLimit(attachments, 10, function (item, callback2) {
-      getAttachment(connection, backupDir, item, callback2, log);
-    }, function (error) {
-      if (error) {
-        log('Error while downloading the attachments: ' + error);
-        callback(error);
-        return;
+    log('attachments: downloading ' + refs.length + ' attachment(s)');
+    return refs;
+  })().then(function (refs) {
+    if (refs.length === 0) return callback();
+    async.mapLimit(refs, concurrency, function (att, done) {
+      downloadOne(connection, writer, stateStore, att, log, done);
+    }, function (err) {
+      if (err) {
+        log('attachments: failed — ' + (err.message || err));
+        return callback(err);
       }
-      log('Download done');
+      log('attachments: done');
       callback();
     });
-
-  }, log);
-
+  }, callback);
 };
 
-/**
- * Create a map
- * @param {*} backupDir 
- * @param {*} log 
- * @returns 
- */
-function loadStreamMapIfNeed(backupDir, log) {
-  if (! backupDir.settingAttachmentUseStreamsPath) return;
-  log('Loading streams Dir');
-  try {
-    const streamsTree = JSON.parse(fs.readFileSync(backupDir.streamsFile, 'utf8')) ;
-    function mapTree(childs, path) {
-      for (const child of childs) {
-        const childPath = path + '/' + child.name.replaceAll('..','__'); // escape all ".."
-        backupDir.streamsMap[child.id] = childPath;
-        if (child.childrens) mapTree(child.childrens, childPath);
-      }
-    }
-    mapTree(streamsTree.streams, '');
-  } catch (error) {
-    log('Error while reading streams: ' + error);
+function downloadOne (connection, writer, stateStore, att, log, callback) {
+  const fileName = att.fileName || att.attId;
+  const relPath = 'attachments/' + att.eventId + '_' + fileName;
+  if (typeof writer.exists === 'function' && writer.exists(relPath)) {
+    log('attachments: skipping existing ' + relPath);
+    return stateStore.markDone(CATEGORY, att.key).then(
+      function () { callback(); },
+      callback
+    );
   }
+  const url = new URL(connection.endpoint);
+  const base = url.protocol + '//' + url.host + url.pathname.replace(/\/$/, '');
+  const fullUrl = base + '/events/' + encodeURIComponent(att.eventId) +
+    '/' + encodeURIComponent(att.attId) +
+    '?readToken=' + encodeURIComponent(att.readToken || '');
+
+  (async function () {
+    const res = await fetch(fullUrl);
+    if (res.status !== 200) {
+      throw new Error('HTTP ' + res.status + ' ' + (res.statusText || '') +
+        ' while fetching ' + relPath);
+    }
+    const writeStream = writer.openWriteStream(relPath);
+    const reader = res.body.getReader();
+    while (true) {
+      const { done: streamDone, value } = await reader.read();
+      if (streamDone) break;
+      writeStream.write(value);
+    }
+    await endStream(writeStream);
+    await stateStore.markDone(CATEGORY, att.key);
+    log('attachments: wrote ' + relPath);
+  })().then(
+    function () { callback(); },
+    function (err) {
+      log('attachments: ' + relPath + ' — ' + (err.message || err));
+      callback(err);
+    }
+  );
 }
 
-function loadEventFile(connection, backupDir, callback, log) {
-  // Walk every event-data file the backup carries — legacy single-file
-  // `events.json` (older backups) and chunked `events-YYYY-MM.json` (0.5.0+)
-  // and incremental `events-incremental-<TS>.json` (0.6.0+). Prior to this
-  // fix, only the legacy file was streamed; chunked-only backups crashed
-  // immediately with `ENOENT events.json` when `--includeAttachments` was
-  // on — the same regression pattern as the 0.6.0 hf-data fix.
-  const eventFiles = (typeof backupDir.listEventFiles === 'function')
-    ? backupDir.listEventFiles()
-    : (fs.existsSync(backupDir.eventsFile) ? [backupDir.eventsFile] : []);
-  if (eventFiles.length === 0) {
-    log('attachments: skipping (no events-*.json files — events fetch must run first)');
-    return callback(null, []);
-  }
-
-  const attachments = [];
-  log('Parsing events for attachments across ' + eventFiles.length + ' file(s)');
-
-  // --- pretty timed log ---//
-  const timeRepeat = 1000;
-  let total = 0;
-  let done = false;
-  const timeLog = function() {
-    if (done) return;
-    log('Parsed ' +  total + ' events, found ' + attachments.length + ' attachments');
-    setTimeout(timeLog, timeRepeat);
-  }
-  setTimeout(timeLog, timeRepeat);
-
-  function streamOne (i) {
-    if (i >= eventFiles.length) {
-      done = true;
-      log('Found ' + attachments.length + ' attachments');
-      return callback(null, attachments);
-    }
-    fs.createReadStream(eventFiles[i], 'utf8').pipe(
-      JSONStream.parse('events.*').on('data', function(event) {
-        total++;
-        if (event.attachments) {
-          event.attachments.forEach(function (att) {
-            if (att.id) {
-              att.eventId = event.id;
-              att.streamId = event.streamId;
-              attachments.push(att);
-            } else {
-              log('Invalid event: att.id is missing: ' + event);
-            }
-          });
-        }
-      }).on('error', function(error) {
-        done = true;
-        log('Error while fetching attachments: ' + error);
-        callback(error, attachments);
-      }).on('end', function() {
-        streamOne(i + 1);
-      }));
-  }
-  streamOne(0);
-}
-
-
-/**
- * Download attachment file and save it on local storage under
- * {eventId_attachmentFileName}.
- * If the file already exists, it is skipped
- *
- * @param attachmentsDir
- * @param attachment
- * @param callback
- */
-async function getAttachment(connection, backupDir, attachment, callback, log) {
-  const attFile = backupDir.getAttachmentFilePath(attachment.fileName, attachment.eventId, attachment.streamId);
-  if (fs.existsSync(attFile)) {
-    log('Skipping already existing attachment: ' + attFile);
-    return callback();
-  }
-
-  const url = new URL(connection.endpoint)
-
-  const options = {
-    host: url.hostname,
-    port: url.port || 443,
-    path: url.pathname + 'events/' +
-    attachment.eventId + '/' + attachment.id + '?readToken=' + attachment.readToken
-  };
-
-  https.get(options, function (res) {
-    let binData = '';
-    res.setEncoding('binary');
-
-    res.on('data', function (chunk) {
-      binData += chunk;
-    });
-
-    res.on('end', function () {
-      fs.writeFile(attFile, binData, 'binary', function (err) {
-        if (err) {
-          log('Error while writing attachment: ' + attFile);
-          throw err;
-        }
-        log('Attachment saved: ' + attFile);
-        callback();
+function endStream (writeStream) {
+  return new Promise(function (resolve, reject) {
+    if (typeof writeStream.end !== 'function') return resolve();
+    try {
+      writeStream.end(function (err) {
+        if (err) return reject(err);
+        resolve();
       });
-    });
-
-  }).on('error', function (e) {
-    log('Error while fetching https://' + options.host + options.path);
-    callback(e);
+    } catch (e) {
+      reject(e);
+    }
   });
 }
+
+exports.CATEGORY = CATEGORY;

--- a/src/methods/events-chunked.js
+++ b/src/methods/events-chunked.js
@@ -48,6 +48,14 @@ exports.download = function download (connection, writer, options, callback, log
   options = options || {};
   const stateAll = options.includeTrashed ? '&state=all' : '';
 
+  // onParsed lift: per-chunk JSON gets re-emitted as the events array. Lets
+  // the orchestrator push attachment / series-event refs to the StateStore
+  // without re-reading files post-fetch.
+  const onEvents = typeof options.onEvents === 'function' ? options.onEvents : null;
+  const onParsed = onEvents
+    ? function (doc) { return onEvents(Array.isArray(doc.events) ? doc.events : []); }
+    : null;
+
   // Incremental mode: single round-trip with modifiedSince.
   if (options.modifiedSince != null) {
     const runTs = options.runStartedAt || Math.floor(Date.now() / 1000);
@@ -59,7 +67,8 @@ exports.download = function download (connection, writer, options, callback, log
       writer: writer,
       resource: resource,
       connection: connection,
-      filename: 'events-incremental-' + runTs + '.json'
+      filename: 'events-incremental-' + runTs + '.json',
+      onParsed: onParsed
     }, callback, log);
     return;
   }
@@ -89,7 +98,8 @@ exports.download = function download (connection, writer, options, callback, log
         writer: writer,
         resource: resource,
         extraFileName: '-' + w.label,
-        connection: connection
+        connection: connection,
+        onParsed: onParsed
       }, function (err) {
         if (err) return callback(err);
         next();

--- a/src/methods/hf-data.js
+++ b/src/methods/hf-data.js
@@ -1,112 +1,115 @@
-const fs = require('fs');
-const path = require('path');
-const https = require('https');
 const async = require('async');
 
+const CATEGORY = 'series-event';
+
 /**
- * For every `series:*` event in `events.json`, fetch the data points via
+ * For every `series:*` event ref queued in the StateStore under the
+ * `series-event` category, fetch its data points via
  * `GET /events/<eventId>/series` and write them to
- * `<backupDir>/hf-data/<eventId>.json` (one file per series event).
+ * `hf-data/<eventId>.json` (one file per series event).
  *
  * Earlier backup versions downloaded the series event "container" but never
- * fetched the actual data points, so a GDPR Art.15 portable dump was missing
- * the bulk of the user's data on any HFS-using deployment.
+ * fetched the actual data points, so a portable dump was missing the bulk of
+ * the user's data on any HFS-using deployment.
  *
- * @param {object} connection { endpoint, token } (pryv lib connection shape)
- * @param {object} backupDir BackupDirectory instance
+ * Browser-isomorphic since v0.7.0:
+ *   - HTTP: global `fetch`,
+ *   - disk: `writer.openWriteStream('hf-data/<eid>.json')`,
+ *   - work queue: `stateStore.listPending('series-event')` populated by the
+ *     orchestrator from the events stream via the `onParsed` hook.
+ *
+ * Ref schema (pushed by the orchestrator):
+ *   { key: '<eventId>', eventId, type }
+ *
+ * @param {object} connection { endpoint, token }
+ * @param {object} writer StorageWriter
+ * @param {object} stateStore StateStore (drains category 'series-event')
+ * @param {object} options { concurrency?: number } default 4
  * @param {function} callback (err)
  * @param {function} [log] optional log function
  */
-exports.download = function (connection, backupDir, callback, log) {
+exports.download = function download (connection, writer, stateStore, options, callback, log) {
   if (!log) log = console.log;
-  // Walk every event-data file the backup carries — legacy single-file
-  // `events.json` (older backups) and chunked `events-YYYY-MM.json` (0.5.0+).
-  // Prior to this fix, only the legacy file was inspected; chunked-only
-  // backups silently skipped series-event discovery and produced an empty
-  // hf-data/ folder, dropping the bulk of HFS-using subjects' data from the
-  // Art.15 / Art.20 bundle.
-  const eventFiles = (typeof backupDir.listEventFiles === 'function')
-    ? backupDir.listEventFiles()
-    : (fs.existsSync(backupDir.eventsFile) ? [backupDir.eventsFile] : []);
-  if (eventFiles.length === 0) {
-    log('hf-data: skipping (no events-*.json files — events fetch must run first)');
-    return callback();
+  if (writer == null || typeof writer.openWriteStream !== 'function') {
+    throw new Error('hf-data.download requires a StorageWriter');
   }
+  if (stateStore == null || typeof stateStore.listPending !== 'function') {
+    throw new Error('hf-data.download requires a StateStore');
+  }
+  options = options || {};
+  const concurrency = options.concurrency || 4;
 
-  const seriesEvents = [];
-  for (const file of eventFiles) {
-    let parsed;
-    try {
-      parsed = JSON.parse(fs.readFileSync(file, 'utf8'));
-    } catch (err) {
-      return callback(err);
+  (async function () {
+    const refs = await stateStore.listPending(CATEGORY);
+    if (refs.length === 0) {
+      log('hf-data: no pending series events, skipping');
+      return [];
     }
-    const events = Array.isArray(parsed.events) ? parsed.events : [];
-    for (const e of events) {
-      if (typeof e.type === 'string' && e.type.indexOf('series:') === 0) {
-        seriesEvents.push(e);
-      }
-    }
-  }
-
-  if (seriesEvents.length === 0) {
-    log('hf-data: no series events found, skipping');
-    return callback();
-  }
-
-  log('hf-data: fetching data points for ' + seriesEvents.length + ' series event(s)');
-  // Native fs.mkdir({recursive:true}) replaces mkdirp (which went ESM-only in v3).
-  fs.promises.mkdir(backupDir.hfDataDir, { recursive: true }).then(function () {
-    async.mapLimit(seriesEvents, 4, function (event, done) {
-      fetchOneSeries(connection, event.id, backupDir.hfDataDir, log, done);
+    log('hf-data: fetching data points for ' + refs.length + ' series event(s)');
+    return refs;
+  })().then(function (refs) {
+    if (refs.length === 0) return callback();
+    async.mapLimit(refs, concurrency, function (ref, done) {
+      fetchOneSeries(connection, writer, stateStore, ref, log, done);
     }, function (err) {
       if (err) return callback(err);
       log('hf-data: done');
       callback();
     });
-  }).catch(callback);
+  }, callback);
 };
 
-function fetchOneSeries (connection, eventId, hfDataDir, log, callback) {
+function fetchOneSeries (connection, writer, stateStore, ref, log, callback) {
+  const eventId = ref.eventId;
   const url = new URL(connection.endpoint);
-  const resourcePath = url.pathname + 'events/' + eventId + '/series';
-  const options = {
-    host: url.hostname,
-    port: url.port || 443,
-    path: resourcePath,
-    headers: { Authorization: connection.token }
-  };
-  const outFile = path.join(hfDataDir, eventId + '.json');
-  const writeStream = fs.createWriteStream(outFile, { encoding: 'utf8' });
-  let total = 0;
-  let done = false;
+  const base = url.protocol + '//' + url.host + url.pathname.replace(/\/$/, '');
+  const fullUrl = base + '/events/' + encodeURIComponent(eventId) + '/series';
+  const relPath = 'hf-data/' + eventId + '.json';
 
-  https.get(options, function (res) {
-    if (res.statusCode !== 200) {
-      done = true;
-      writeStream.end();
-      // 404 / 400 on an empty series is non-fatal — just log and skip.
-      log('hf-data: skipping ' + eventId + ' (HTTP ' + res.statusCode + ')');
-      try { fs.unlinkSync(outFile); } catch (_e) { /* ignore */ }
-      return callback();
+  (async function () {
+    const res = await fetch(fullUrl, {
+      headers: { Authorization: connection.token }
+    });
+    if (res.status !== 200) {
+      // 404 / 400 on an empty series is non-fatal — log + mark done so the
+      // ref doesn't re-queue indefinitely on re-runs.
+      log('hf-data: skipping ' + eventId + ' (HTTP ' + res.status + ')');
+      await stateStore.markDone(CATEGORY, ref.key);
+      return;
     }
-    res.setEncoding('utf8');
-    res.on('data', function (chunk) {
-      total += chunk.length;
-      writeStream.write(chunk);
-    });
-    res.on('end', function () {
-      done = true;
-      writeStream.end(function () {
-        log('hf-data: ' + eventId + ' (' + total + ' bytes)');
-        callback();
+    const writeStream = writer.openWriteStream(relPath);
+    const reader = res.body.getReader();
+    let total = 0;
+    while (true) {
+      const { done: streamDone, value } = await reader.read();
+      if (streamDone) break;
+      total += value.byteLength;
+      writeStream.write(value);
+    }
+    await endStream(writeStream);
+    await stateStore.markDone(CATEGORY, ref.key);
+    log('hf-data: ' + eventId + ' (' + total + ' bytes)');
+  })().then(
+    function () { callback(); },
+    function (err) {
+      log('hf-data: error fetching ' + eventId + ' — ' + (err.message || err));
+      callback(err);
+    }
+  );
+}
+
+function endStream (writeStream) {
+  return new Promise(function (resolve, reject) {
+    if (typeof writeStream.end !== 'function') return resolve();
+    try {
+      writeStream.end(function (err) {
+        if (err) return reject(err);
+        resolve();
       });
-    });
-  }).on('error', function (e) {
-    if (done) return;
-    done = true;
-    writeStream.end();
-    log('hf-data: error fetching ' + eventId + ' — ' + e.message);
-    callback(e);
+    } catch (e) {
+      reject(e);
+    }
   });
 }
+
+exports.CATEGORY = CATEGORY;

--- a/src/methods/webhooks-export.js
+++ b/src/methods/webhooks-export.js
@@ -1,16 +1,25 @@
-const fs = require('fs');
-const https = require('https');
 const async = require('async');
 
+const CATEGORY = 'webhook';
+
 /**
- * For every access in `accesses.json`, call `GET /webhooks` with that access's
- * token and aggregate the result into `<backupDir>/webhooks.json` keyed by
- * accessId.
+ * For every access ref queued in the StateStore under the `webhook` category,
+ * call `GET /webhooks` with that access's token and aggregate the result into
+ * `<baseDir>/webhooks.json` keyed by accessId.
  *
- * Earlier backup versions never fetched webhooks at all, so the DSAR dump
+ * Earlier backup versions never fetched webhooks at all, so the disclosure
  * was missing every webhook the subject had configured. Per-access fetch
  * matches the API's permissions model (each access only sees its own
  * webhooks; the personal access sees all).
+ *
+ * Browser-isomorphic since v0.7.0:
+ *   - HTTP: global `fetch` (uniform handling of http vs https),
+ *   - disk: `writer.openWriteStream('webhooks.json')`,
+ *   - work queue: `stateStore.listPending('webhook')` populated by the
+ *     orchestrator from the accesses payload via the `onParsed` hook.
+ *
+ * Ref schema (pushed by the orchestrator):
+ *   { key: '<accessId>', accessId, token, type }
  *
  * Output shape:
  *   {
@@ -19,106 +28,103 @@ const async = require('async');
  *     "webhooks": [ { ...webhook, accessId } ]
  *   }
  *
- * @param {object} connection { endpoint, token } (only used to derive the
- *   API host — the per-access token is what authenticates each request).
- * @param {object} backupDir BackupDirectory instance
+ * @param {object} connection { endpoint, token }
+ * @param {object} writer StorageWriter
+ * @param {object} stateStore StateStore (drains category 'webhook')
+ * @param {object} options { concurrency?: number } default 4
  * @param {function} callback (err)
  * @param {function} [log] optional log function
  */
-exports.download = function (connection, backupDir, callback, log) {
+exports.download = function download (connection, writer, stateStore, options, callback, log) {
   if (!log) log = console.log;
-  const accessesFile = backupDir.accessesFile;
-  if (!fs.existsSync(accessesFile)) {
-    log('webhooks-export: skipping (no accesses.json — accesses fetch must run first)');
-    return callback();
+  if (writer == null || typeof writer.openWriteStream !== 'function') {
+    throw new Error('webhooks-export.download requires a StorageWriter');
   }
-
-  let parsed;
-  try {
-    parsed = JSON.parse(fs.readFileSync(accessesFile, 'utf8'));
-  } catch (err) {
-    return callback(err);
+  if (stateStore == null || typeof stateStore.listPending !== 'function') {
+    throw new Error('webhooks-export.download requires a StateStore');
   }
-  const accesses = Array.isArray(parsed.accesses) ? parsed.accesses : [];
-  // We only call /webhooks on accesses that actually carry a usable token.
-  const scannable = accesses.filter(function (a) {
-    return typeof a.token === 'string' && a.token.length > 0;
-  });
+  options = options || {};
+  const concurrency = options.concurrency || 4;
 
-  if (scannable.length === 0) {
-    log('webhooks-export: no scannable accesses, skipping');
-    return writeOutput(backupDir, scannable.length, [], log, callback);
-  }
+  (async function () {
+    const refs = await stateStore.listPending(CATEGORY);
+    if (refs.length === 0) {
+      log('webhooks-export: no scannable accesses, writing empty bundle');
+      return [];
+    }
+    log('webhooks-export: scanning ' + refs.length + ' access(es)');
+    return refs;
+  })().then(function (refs) {
+    const apiUrl = new URL(connection.endpoint);
+    const collected = [];
 
-  log('webhooks-export: scanning ' + scannable.length + ' access(es)');
-  const apiUrl = new URL(connection.endpoint);
-  const collected = [];
-
-  async.mapLimit(scannable, 4, function (access, done) {
-    fetchWebhooksForAccess(apiUrl, access, log, function (err, list) {
-      if (err) return done(err);
-      list.forEach(function (w) {
-        w.accessId = access.id;
-        collected.push(w);
+    async.mapLimit(refs, concurrency, function (ref, done) {
+      fetchWebhooksForAccess(apiUrl, ref, log, function (err, list) {
+        if (err) return done(err);
+        list.forEach(function (w) {
+          w.accessId = ref.accessId;
+          collected.push(w);
+        });
+        stateStore.markDone(CATEGORY, ref.key).then(function () { done(); }, done);
       });
-      done();
+    }, function (err) {
+      if (err) return callback(err);
+      writeOutput(writer, refs.length, collected, log, callback);
     });
-  }, function (err) {
-    if (err) return callback(err);
-    writeOutput(backupDir, scannable.length, collected, log, callback);
-  });
+  }, callback);
 };
 
-function writeOutput (backupDir, accessesScanned, webhooks, log, callback) {
+function writeOutput (writer, accessesScanned, webhooks, log, callback) {
   const out = {
     generated_at: new Date().toISOString(),
     accesses_scanned: accessesScanned,
-    webhooks
+    webhooks: webhooks
   };
-  fs.writeFile(backupDir.webhooksFile, JSON.stringify(out, null, 2), 'utf8', function (err) {
-    if (err) return callback(err);
-    log('webhooks-export: wrote ' + webhooks.length + ' webhook(s) to ' + backupDir.webhooksFile);
+  const writeStream = writer.openWriteStream('webhooks.json');
+  writeStream.write(JSON.stringify(out, null, 2));
+  if (typeof writeStream.end === 'function') {
+    writeStream.end(function (err) {
+      if (err) return callback(err);
+      log('webhooks-export: wrote ' + webhooks.length + ' webhook(s) to webhooks.json');
+      callback();
+    });
+  } else {
+    log('webhooks-export: wrote ' + webhooks.length + ' webhook(s) to webhooks.json');
     callback();
-  });
+  }
 }
 
-function fetchWebhooksForAccess (apiUrl, access, log, callback) {
-  // Pick http or https based on the apiEndpoint scheme — required for
-  // dev / lab deployments that run HTTP-only (the QuickStart on mbp2,
-  // CI fixtures, etc.). Production always uses https.
-  const transport = apiUrl.protocol === 'http:' ? require('http') : https;
-  const options = {
-    host: apiUrl.hostname,
-    port: apiUrl.port || (apiUrl.protocol === 'http:' ? 80 : 443),
-    path: apiUrl.pathname + 'webhooks',
-    headers: { Authorization: access.token }
-  };
-  const chunks = [];
-  transport.get(options, function (res) {
-    if (res.statusCode === 401 || res.statusCode === 403) {
-      // Expected for expired tokens — skip silently.
-      log('webhooks-export: access ' + access.id + ' rejected (HTTP ' + res.statusCode + '), skipping');
-      return callback(null, []);
-    }
-    if (res.statusCode !== 200) {
-      log('webhooks-export: access ' + access.id + ' returned HTTP ' + res.statusCode + ', skipping');
-      return callback(null, []);
-    }
-    res.setEncoding('utf8');
-    res.on('data', (c) => chunks.push(c));
-    res.on('end', function () {
-      let body;
-      try {
-        body = JSON.parse(chunks.join(''));
-      } catch (parseErr) {
-        log('webhooks-export: access ' + access.id + ' returned unparseable body, skipping');
-        return callback(null, []);
-      }
-      const list = Array.isArray(body.webhooks) ? body.webhooks : [];
-      callback(null, list);
+function fetchWebhooksForAccess (apiUrl, ref, log, callback) {
+  const base = apiUrl.protocol + '//' + apiUrl.host + apiUrl.pathname.replace(/\/$/, '');
+  const fullUrl = base + '/webhooks';
+  (async function () {
+    const res = await fetch(fullUrl, {
+      headers: { Authorization: ref.token }
     });
-  }).on('error', function (e) {
-    log('webhooks-export: access ' + access.id + ' transport error — ' + e.message);
-    callback(null, []); // non-fatal — keep going for the rest of accesses
-  });
+    if (res.status === 401 || res.status === 403) {
+      // Expected for expired tokens — skip silently.
+      log('webhooks-export: access ' + ref.accessId + ' rejected (HTTP ' + res.status + '), skipping');
+      return [];
+    }
+    if (res.status !== 200) {
+      log('webhooks-export: access ' + ref.accessId + ' returned HTTP ' + res.status + ', skipping');
+      return [];
+    }
+    let body;
+    try {
+      body = await res.json();
+    } catch (parseErr) {
+      log('webhooks-export: access ' + ref.accessId + ' returned unparseable body, skipping');
+      return [];
+    }
+    return Array.isArray(body.webhooks) ? body.webhooks : [];
+  })().then(
+    function (list) { callback(null, list); },
+    function (e) {
+      log('webhooks-export: access ' + ref.accessId + ' transport error — ' + (e.message || e));
+      callback(null, []); // non-fatal — keep going for the rest of accesses
+    }
+  );
 }
+
+exports.CATEGORY = CATEGORY;

--- a/test/unit/adapters.test.js
+++ b/test/unit/adapters.test.js
@@ -140,7 +140,7 @@ describe('lib adapters', function () {
     });
 
     it('tolerates a corrupted sentinel file (treats as empty)', async function () {
-      const stateFile = path.join(tmpDir, '.state.json');
+      const stateFile = path.join(tmpDir, '.sync-state.json');
       fs.writeFileSync(stateFile, '{not valid json');
       const s = new FolderStateStore(tmpDir);
       const all = await s.getAll();
@@ -153,6 +153,150 @@ describe('lib adapters', function () {
       const all = await s.getAll();
       all.k = 999;
       (await s.get('k')).should.equal(1);
+    });
+
+    it('migrates from the pre-v0.7.0 .state.json layout', async function () {
+      const migrateDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fss-migrate-'));
+      try {
+        const legacy = path.join(migrateDir, '.state.json');
+        fs.writeFileSync(legacy, JSON.stringify({
+          lastRunAt: 1700000000,
+          'events.lastModifiedSince': 1699000000
+        }));
+        const s = new FolderStateStore(migrateDir);
+        (await s.get('lastRunAt')).should.equal(1700000000);
+        (await s.get('events.lastModifiedSince')).should.equal(1699000000);
+        // Next write lands in the new file.
+        await s.set('k', 'v');
+        fs.existsSync(path.join(migrateDir, '.sync-state.json')).should.equal(true);
+      } finally {
+        fs.rmSync(migrateDir, { recursive: true, force: true });
+      }
+    });
+  });
+
+  describe('[PAAB] FolderStateStore ref tracking', function () {
+    let tmpDir;
+    beforeEach(function () {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fss-refs-'));
+    });
+    afterEach(function () {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('pushRef + listPending round-trips a ref payload', async function () {
+      const s = new FolderStateStore(tmpDir);
+      await s.pushRef('attachment', { key: 'e1:a1', eventId: 'e1', attId: 'a1', fileName: 'foo.bin' });
+      const pending = await s.listPending('attachment');
+      pending.length.should.equal(1);
+      pending[0].key.should.equal('e1:a1');
+      pending[0].fileName.should.equal('foo.bin');
+    });
+
+    it('pushRef is idempotent on key within a category', async function () {
+      const s = new FolderStateStore(tmpDir);
+      await s.pushRef('attachment', { key: 'e1:a1', fileName: 'foo.bin' });
+      await s.pushRef('attachment', { key: 'e1:a1', fileName: 'bar.bin' });
+      const pending = await s.listPending('attachment');
+      pending.length.should.equal(1);
+      pending[0].fileName.should.equal('foo.bin');
+    });
+
+    it('markDone removes the ref from listPending', async function () {
+      const s = new FolderStateStore(tmpDir);
+      await s.pushRef('attachment', { key: 'e1:a1' });
+      await s.pushRef('attachment', { key: 'e2:a2' });
+      await s.markDone('attachment', 'e1:a1');
+      const pending = await s.listPending('attachment');
+      pending.length.should.equal(1);
+      pending[0].key.should.equal('e2:a2');
+    });
+
+    it('clearCategory drops every ref under the category', async function () {
+      const s = new FolderStateStore(tmpDir);
+      await s.pushRef('attachment', { key: 'a' });
+      await s.pushRef('webhook', { key: 'b' });
+      await s.clearCategory('attachment');
+      (await s.listPending('attachment')).should.eql([]);
+      (await s.listPending('webhook')).length.should.equal(1);
+    });
+
+    it('refs survive across instances (persist + reload)', async function () {
+      const s1 = new FolderStateStore(tmpDir);
+      await s1.pushRef('attachment', { key: 'e1:a1', readToken: 'tok' });
+      const s2 = new FolderStateStore(tmpDir);
+      const pending = await s2.listPending('attachment');
+      pending[0].readToken.should.equal('tok');
+    });
+
+    it('pushRef requires ref.key', async function () {
+      const s = new FolderStateStore(tmpDir);
+      let threw = false;
+      try { await s.pushRef('attachment', { eventId: 'e1' }); } catch (e) { threw = /ref\.key/.test(e.message); }
+      threw.should.equal(true);
+    });
+  });
+
+  describe('[PAAB] FolderStateStore export / import', function () {
+    let tmpDir;
+    beforeEach(function () {
+      tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'fss-export-'));
+    });
+    afterEach(function () {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('export() returns the schema envelope + kv state (refs dropped)', async function () {
+      const s = new FolderStateStore(tmpDir);
+      await s.set('lastRunAt', 1700000000);
+      await s.set('toolVersion', '0.7.0');
+      await s.pushRef('attachment', { key: 'e1:a1' });
+      const snapshot = await s.export();
+      snapshot.format.should.equal('pryv-account-backup-sync-state');
+      snapshot.formatVersion.should.equal(1);
+      snapshot.toolVersion.should.equal('0.7.0');
+      snapshot.kv.lastRunAt.should.equal(1700000000);
+      should(snapshot.refs).equal(undefined);
+    });
+
+    it('import() replaces kv state from a prior snapshot', async function () {
+      const s = new FolderStateStore(tmpDir);
+      await s.set('a', 1);
+      await s.import({
+        format: 'pryv-account-backup-sync-state',
+        formatVersion: 1,
+        kv: { b: 2 }
+      });
+      const all = await s.getAll();
+      all.should.eql({ b: 2 });
+    });
+
+    it('import() rejects an unrecognized format', async function () {
+      const s = new FolderStateStore(tmpDir);
+      let threw = false;
+      try { await s.import({ format: 'something-else', formatVersion: 1, kv: {} }); }
+      catch (e) { threw = /format/.test(e.message); }
+      threw.should.equal(true);
+    });
+
+    it('import() rejects an unsupported formatVersion', async function () {
+      const s = new FolderStateStore(tmpDir);
+      let threw = false;
+      try { await s.import({ format: 'pryv-account-backup-sync-state', formatVersion: 99, kv: {} }); }
+      catch (e) { threw = /formatVersion/.test(e.message); }
+      threw.should.equal(true);
+    });
+
+    it('import() does NOT replace refs (those are per-run)', async function () {
+      const s = new FolderStateStore(tmpDir);
+      await s.pushRef('attachment', { key: 'e1:a1' });
+      await s.import({
+        format: 'pryv-account-backup-sync-state',
+        formatVersion: 1,
+        kv: {}
+      });
+      const pending = await s.listPending('attachment');
+      pending.length.should.equal(1);
     });
   });
 

--- a/test/unit/incremental.test.js
+++ b/test/unit/incremental.test.js
@@ -174,83 +174,98 @@ describe('[PAAU] audit-as-events query construction', function () {
   });
 });
 
-// ─── [PAHF] hf-data multi-file discovery (regression fix) ───
+// ─── [PAHF] hf-data series-event drain (v0.7.0 contract) ───
 //
-// Pre-fix, hf-data.js only inspected the legacy `events.json` and silently
-// skipped chunked `events-YYYY-MM.json` files — every v0.5.0 backup of an
-// HFS-using account dropped the bulk of the subject's data without warning.
+// The orchestrator now extracts series-event refs as `events-*.json` files
+// stream by (via `onEvents` in events-chunked → `state.pushRef`). hf-data
+// drains them. These tests cover the drain side; the events-chunked tee
+// side is covered in [PALI] below.
 
-describe('[PAHF] hf-data multi-file series discovery', function () {
+describe('[PAHF] hf-data drains series-event refs from StateStore', function () {
   let tmpDir;
-  let dir;
+  let store;
+  let originalFetch;
+  let fetchCalls;
 
   before(function () {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hfd-test-'));
-    dir = new BackupDirectory('https://token@host.example.com/', tmpDir);
-    fs.mkdirSync(dir.baseDir, { recursive: true });
   });
 
   after(function () {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
-  it('discovers series events from chunked files (events-YYYY-MM.json only)', function (done) {
-    // Two chunked files; one carries a series event.
-    fs.writeFileSync(path.join(dir.baseDir, 'events-2024-01.json'),
-      JSON.stringify({ events: [{ id: 'e1', type: 'note/txt' }] }));
-    fs.writeFileSync(path.join(dir.baseDir, 'events-2024-02.json'),
-      JSON.stringify({ events: [{ id: 'e2', type: 'series:mass/kg' }] }));
-
-    // Stub a connection that NEVER answers — the test only verifies the
-    // skip-decision logic. Stub https.get to short-circuit so no socket opens.
-    const https = require('https');
-    const originalGet = https.get;
-    let attempted = false;
-    https.get = function (opts, cb) {
-      attempted = true;
-      // Provide a phony 200 response with empty body to satisfy hf-data flow.
-      const EventEmitter = require('events');
-      const res = new EventEmitter();
-      res.statusCode = 200;
-      res.setEncoding = () => {};
-      setImmediate(() => {
-        cb(res);
-        res.emit('end');
+  beforeEach(function () {
+    store = new FolderStateStore(tmpDir);
+    fetchCalls = [];
+    originalFetch = global.fetch;
+    global.fetch = function (url) {
+      fetchCalls.push(url);
+      const body = JSON.stringify({ events: [] });
+      const encoded = new TextEncoder().encode(body);
+      let yielded = false;
+      return Promise.resolve({
+        status: 200,
+        statusText: 'OK',
+        body: {
+          getReader () {
+            return {
+              read () {
+                if (yielded) return Promise.resolve({ done: true });
+                yielded = true;
+                return Promise.resolve({ done: false, value: encoded });
+              }
+            };
+          }
+        }
       });
-      return { on: () => {} };
     };
-
-    hfData.download(
-      { endpoint: 'https://x.example.com/', token: 't' },
-      dir,
-      function (err) {
-        https.get = originalGet;
-        should.not.exist(err);
-        // Confirm hf-data ACTUALLY attempted to fetch — pre-fix this would
-        // never reach the https.get call because the legacy `events.json`
-        // path didn't exist.
-        attempted.should.equal(true);
-        done();
-      },
-      () => {}
-    );
   });
 
-  it('falls through to skip when no event files exist at all', function (done) {
-    const emptyTmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hfd-empty-'));
-    const emptyDir = new BackupDirectory('https://token@host.example.com/', emptyTmpDir);
-    fs.mkdirSync(emptyDir.baseDir, { recursive: true });
+  afterEach(async function () {
+    global.fetch = originalFetch;
+    await store.clearCategory('series-event');
+  });
 
-    hfData.download(
-      { endpoint: 'https://x.example.com/', token: 't' },
-      emptyDir,
-      function (err) {
-        should.not.exist(err);
-        fs.rmSync(emptyTmpDir, { recursive: true, force: true });
-        done();
-      },
-      () => {}
-    );
+  const fakeWriter = {
+    openWriteStream: () => ({ write: () => {}, end: (cb) => cb && cb() }),
+    exists: () => false,
+    describeTarget: () => '/mock/'
+  };
+
+  it('fetches one series resource per pending ref', async function () {
+    await store.pushRef('series-event', { key: 'e1', eventId: 'e1', type: 'series:mass/kg' });
+    await store.pushRef('series-event', { key: 'e2', eventId: 'e2', type: 'series:position/wgs84' });
+
+    await new Promise((resolve, reject) => {
+      hfData.download(
+        { endpoint: 'https://token@host.example.com/', token: 't' },
+        fakeWriter,
+        store,
+        {},
+        (err) => err ? reject(err) : resolve(),
+        () => {}
+      );
+    });
+
+    fetchCalls.length.should.equal(2);
+    fetchCalls[0].should.match(/\/events\/e1\/series$/);
+    fetchCalls[1].should.match(/\/events\/e2\/series$/);
+    (await store.listPending('series-event')).should.eql([]); // both drained
+  });
+
+  it('skips cleanly when no refs are pending', async function () {
+    await new Promise((resolve, reject) => {
+      hfData.download(
+        { endpoint: 'https://token@host.example.com/', token: 't' },
+        fakeWriter,
+        store,
+        {},
+        (err) => err ? reject(err) : resolve(),
+        () => {}
+      );
+    });
+    fetchCalls.length.should.equal(0);
   });
 });
 

--- a/test/unit/isomorphism.test.js
+++ b/test/unit/isomorphism.test.js
@@ -9,6 +9,9 @@ const apiResources = require('../../src/methods/api-resources');
 const eventsChunked = require('../../src/methods/events-chunked');
 const auditAsEvents = require('../../src/methods/audit-as-events');
 const accessesHistory = require('../../src/methods/accesses-history');
+const attachments = require('../../src/methods/attachments');
+const webhooksExport = require('../../src/methods/webhooks-export');
+const FolderStateStore = require('../../src/lib/adapters/FolderStateStore');
 
 /**
  * [PALI] — Library Isomorphism contract: the four browser-portable per-method
@@ -214,6 +217,303 @@ describe('[PALI] library isomorphism contract', function () {
         function (err) {
           should.not.exist(err);
           writeCalls.length.should.equal(0);
+          done();
+        },
+        () => {}
+      );
+    });
+  });
+
+  // ─── [PALI-A] attachments.download drains the `attachment` category ───
+
+  describe('[PALI-A] attachments.download', function () {
+    let storeDir;
+    let store;
+
+    beforeEach(function () {
+      storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pali-a-'));
+      store = new FolderStateStore(storeDir);
+      // Binary attachments: stub fetch to return a fixed payload.
+      global.fetch = function (url) {
+        const payload = new TextEncoder().encode('PNG-bytes-for-' + url);
+        let yielded = false;
+        return Promise.resolve({
+          status: 200,
+          statusText: 'OK',
+          body: {
+            getReader () {
+              return {
+                read () {
+                  if (yielded) return Promise.resolve({ done: true });
+                  yielded = true;
+                  return Promise.resolve({ done: false, value: payload });
+                }
+              };
+            }
+          }
+        });
+      };
+    });
+
+    afterEach(function () {
+      fs.rmSync(storeDir, { recursive: true, force: true });
+    });
+
+    it('throws synchronously when StateStore is missing', function () {
+      (() => attachments.download(
+        { endpoint: 'https://x/', token: 't' },
+        fakeWriter,
+        null,
+        {},
+        () => {},
+        () => {}
+      )).should.throw(/StateStore/);
+    });
+
+    it('throws synchronously when writer is missing', function () {
+      (() => attachments.download(
+        { endpoint: 'https://x/', token: 't' },
+        null,
+        store,
+        {},
+        () => {},
+        () => {}
+      )).should.throw(/StorageWriter/);
+    });
+
+    it('writes one attachments/<eid>_<fileName> per pending ref + marks each done', async function () {
+      await store.pushRef('attachment', {
+        key: 'e1:a1', eventId: 'e1', attId: 'a1', fileName: 'photo.png', readToken: 'rt1'
+      });
+      await store.pushRef('attachment', {
+        key: 'e1:a2', eventId: 'e1', attId: 'a2', fileName: 'doc.pdf', readToken: 'rt2'
+      });
+
+      await new Promise((resolve, reject) => {
+        attachments.download(
+          { endpoint: 'https://token@host.example.com/', token: 't' },
+          fakeWriter,
+          store,
+          {},
+          (err) => err ? reject(err) : resolve(),
+          () => {}
+        );
+      });
+
+      const paths = writeCalls.map((w) => w.path).sort();
+      paths.should.eql(['attachments/e1_doc.pdf', 'attachments/e1_photo.png']);
+      (await store.listPending('attachment')).should.eql([]);
+    });
+
+    it('writes nothing when no refs are pending', async function () {
+      await new Promise((resolve, reject) => {
+        attachments.download(
+          { endpoint: 'https://token@host.example.com/', token: 't' },
+          fakeWriter,
+          store,
+          {},
+          (err) => err ? reject(err) : resolve(),
+          () => {}
+        );
+      });
+      writeCalls.length.should.equal(0);
+    });
+  });
+
+  // ─── [PALI-W] webhooks-export.download drains the `webhook` category ───
+
+  describe('[PALI-W] webhooks-export.download', function () {
+    let storeDir;
+    let store;
+    let fetchUrls;
+
+    beforeEach(function () {
+      storeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pali-w-'));
+      store = new FolderStateStore(storeDir);
+      fetchUrls = [];
+      global.fetch = function (url) {
+        fetchUrls.push(url);
+        return Promise.resolve({
+          status: 200,
+          json: () => Promise.resolve({ webhooks: [{ id: 'wh-' + fetchUrls.length, url: 'https://hook' }] })
+        });
+      };
+    });
+
+    afterEach(function () {
+      fs.rmSync(storeDir, { recursive: true, force: true });
+    });
+
+    it('hits /webhooks once per pending access ref + tags each result with accessId', async function () {
+      await store.pushRef('webhook', { key: 'acc-1', accessId: 'acc-1', token: 'tok-1', type: 'app' });
+      await store.pushRef('webhook', { key: 'acc-2', accessId: 'acc-2', token: 'tok-2', type: 'shared' });
+
+      await new Promise((resolve, reject) => {
+        webhooksExport.download(
+          { endpoint: 'https://token@host.example.com/', token: 't' },
+          fakeWriter,
+          store,
+          {},
+          (err) => err ? reject(err) : resolve(),
+          () => {}
+        );
+      });
+
+      fetchUrls.length.should.equal(2);
+      writeCalls.length.should.equal(1);
+      writeCalls[0].path.should.equal('webhooks.json');
+      const body = JSON.parse(writeCalls[0].chunks.map((b) => Buffer.from(b).toString()).join(''));
+      body.accesses_scanned.should.equal(2);
+      body.webhooks.length.should.equal(2);
+      body.webhooks.map((w) => w.accessId).sort().should.eql(['acc-1', 'acc-2']);
+      (await store.listPending('webhook')).should.eql([]);
+    });
+
+    it('still writes a bundle when no accesses are scannable', async function () {
+      await new Promise((resolve, reject) => {
+        webhooksExport.download(
+          { endpoint: 'https://token@host.example.com/', token: 't' },
+          fakeWriter,
+          store,
+          {},
+          (err) => err ? reject(err) : resolve(),
+          () => {}
+        );
+      });
+      writeCalls.length.should.equal(1);
+      writeCalls[0].path.should.equal('webhooks.json');
+      const body = JSON.parse(writeCalls[0].chunks.map((b) => Buffer.from(b).toString()).join(''));
+      body.accesses_scanned.should.equal(0);
+      body.webhooks.should.eql([]);
+    });
+  });
+
+  // ─── [PALI-S] api-resources onParsed tee + events-chunked onEvents lift ───
+
+  describe('[PALI-S] api-resources onParsed hook', function () {
+    let receivedDoc;
+
+    beforeEach(function () {
+      receivedDoc = null;
+      // Stream-style fetch with a parseable JSON body.
+      global.fetch = function () {
+        const payload = new TextEncoder().encode(JSON.stringify({
+          accesses: [{ id: 'acc-1', token: 'tok' }],
+          meta: { v: 1 }
+        }));
+        let yielded = false;
+        return Promise.resolve({
+          status: 200,
+          statusText: 'OK',
+          body: {
+            getReader () {
+              return {
+                read () {
+                  if (yielded) return Promise.resolve({ done: true });
+                  yielded = true;
+                  return Promise.resolve({ done: false, value: payload });
+                }
+              };
+            }
+          }
+        });
+      };
+    });
+
+    it('tees response bytes + parses + invokes onParsed when supplied', function (done) {
+      apiResources.toJSONFile({
+        writer: fakeWriter,
+        resource: 'accesses',
+        connection: { endpoint: 'https://token@host.example.com/', token: 't' },
+        onParsed: (doc) => { receivedDoc = doc; }
+      }, function (err) {
+        should.not.exist(err);
+        receivedDoc.should.not.equal(null);
+        receivedDoc.accesses[0].id.should.equal('acc-1');
+        receivedDoc.meta.v.should.equal(1);
+        // Bytes still flowed to the writer.
+        writeCalls.length.should.equal(1);
+        done();
+      }, () => {});
+    });
+
+    it('skips onParsed silently when the body is not valid JSON', function (done) {
+      global.fetch = function () {
+        const payload = new TextEncoder().encode('{not valid json');
+        let yielded = false;
+        return Promise.resolve({
+          status: 200,
+          body: {
+            getReader () {
+              return {
+                read () {
+                  if (yielded) return Promise.resolve({ done: true });
+                  yielded = true;
+                  return Promise.resolve({ done: false, value: payload });
+                }
+              };
+            }
+          }
+        });
+      };
+      apiResources.toJSONFile({
+        writer: fakeWriter,
+        resource: 'accesses',
+        connection: { endpoint: 'https://x/', token: 't' },
+        onParsed: (doc) => { receivedDoc = doc; }
+      }, function (err) {
+        should.not.exist(err);
+        should(receivedDoc).equal(null); // unparseable → onParsed not called
+        done();
+      }, () => {});
+    });
+  });
+
+  describe('[PALI-S] events-chunked onEvents lift', function () {
+    let receivedBatches;
+
+    beforeEach(function () {
+      receivedBatches = [];
+      global.fetch = function () {
+        const payload = new TextEncoder().encode(JSON.stringify({
+          events: [
+            { id: 'e1', type: 'note/txt' },
+            { id: 'e2', type: 'series:mass/kg' }
+          ]
+        }));
+        let yielded = false;
+        return Promise.resolve({
+          status: 200,
+          body: {
+            getReader () {
+              return {
+                read () {
+                  if (yielded) return Promise.resolve({ done: true });
+                  yielded = true;
+                  return Promise.resolve({ done: false, value: payload });
+                }
+              };
+            }
+          }
+        });
+      };
+    });
+
+    it('forwards parsed events to onEvents in incremental mode', function (done) {
+      eventsChunked.download(
+        { endpoint: 'https://token@host.example.com/', token: 't' },
+        fakeWriter,
+        {
+          modifiedSince: 1700000000,
+          runStartedAt: 1700100000,
+          onEvents: (events) => { receivedBatches.push(events); }
+        },
+        function (err) {
+          should.not.exist(err);
+          receivedBatches.length.should.equal(1);
+          receivedBatches[0].length.should.equal(2);
+          receivedBatches[0][0].id.should.equal('e1');
+          receivedBatches[0][1].type.should.equal('series:mass/kg');
           done();
         },
         () => {}


### PR DESCRIPTION
## Summary

Closes the v0.6.0 webapp coverage gap. The three remaining Node-only resource fetchers (`attachments`, `hf-data`, `webhooks-export`) are refactored to the same `fetch` + `StorageWriter` shape as the v0.6.0 four — fed by per-category work refs tracked in the `StateStore`. Subjects answering a DSAR through the sample webapp can now get attachments, HFS series data points, and webhooks alongside the read-side text resources.

A portable `sync-state.json` is also written at run-end (CLI: backup-dir root; webapp: inside the final ZIP) — kv-only snapshot of incremental thresholds + tool/format version. Subject keeps it alongside the backup; CLI auto-reads on the next run, webapp accepts it as an upload for cross-browser / cross-device incremental.

## What's in this PR

- **`StateStore` interface extended**: per-category work refs (`pushRef` / `listPending` / `markDone` / `clearCategory`) + portable `export()` / `import(data)`. `FolderStateStore` implements with eager flush; auto-migrates from pre-v0.7.0 `.state.json` to `.sync-state.json`.
- **`api-resources.toJSONFile` `onParsed(doc)` tee**: opt-in callback that accumulates response bytes alongside writing and JSON-decodes at end of stream. `events-chunked.download` lifts that into `onEvents(events[])`. The orchestrator wires both to push refs into the store.
- **`attachments` / `hf-data` / `webhooks-export` refactor**: `download(connection, writer, stateStore, options, cb, log)`. Each drains its category, calls `markDone` per success, handles 401/403 (webhooks) / 404 (hf-data) non-fatally.
- **Attachment layout simplified**: flat `attachments/<eventId>_<fileName>`. Drops the opt-in stream-path-mirrored layout that referenced an undeclared `mkdirp` helper (latent bug — would have crashed on any account with a top-level streamId match).
- **`Backup.run` now requires a `StateStore`** — raises a clear error if absent.
- **`docs/sync-state.md`**: schema doc for the portable file.
- **`JSONStream` dep dropped** — was only used by attachments.js.

## Tests

`npx mocha test/unit/{adapters,incremental,isomorphism,events-chunked,manifest}.test.js` — **81 passing**:

- 12 new `[PAAB] FolderStateStore` tests covering ref tracking + export/import + migration.
- 4 new `[PALI]` isomorphism-contract tests covering the three refactored modules + the `onParsed` tee.
- `[PAHF]` reshaped from the old disk-walk contract to the new drain-from-store contract.

## Smoke-tested

End-to-end against a real Pryv account on `pryv.me`:

| Run | ZIP | Requests | Coverage |
|---|---|---|---|
| Initial, no attachments | 75 KB | 102 (76 events month-chunks + audit + 11 webhooks + ...) | webhooks 11/11 done (8 × 200 + 3 × 403 silent) |
| Incremental run | 18 KB | 36 (single `events?modifiedSince` + audit + 11 access-history + webhooks) | thresholds bumped; refs re-discovered |
| Initial + Include attachments | 543 KB | 110 (76 month-chunks + 8 attachment binary streams + webhooks) | attachments 8/8 done, all binaries streamed via `fetch` → `writer.openWriteStream` |

The smoke surfaced + fixed one bundler bug downstream in the webapp (esbuild was stubbing `async`); the library side was clean throughout.

## CLI behavior preserved

`scripts/start-backup.js` prompts are unchanged. The `require('@pryv/account-backup').start(params, callback)` entry point is preserved verbatim.

## Test plan

- [ ] CI green
- [ ] Manual: `npm install && npm start` against any v2 deployment; output identical shape to v0.6.0 with the addition of a top-level `sync-state.json`
- [ ] Manual: re-run on the same backup directory; observe the incremental single-call events fetch + ref re-discovery
- [ ] Tag `v0.7.0` after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)